### PR TITLE
 Add configurable consistency level and local DC

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,8 @@ In addition to the configuration parameters described in the ["Configuration"](#
 | --- | --- |
 | `scylla.query.time.window.size` | The size of windows queried by the connector. Changes are queried using `SELECT` statements with time restriction with width defined by this parameter. Value expressed in milliseconds. |
 | `scylla.confidence.window.size` | The size of the confidence window. It is necessary for the connector to avoid reading too fresh data from the CDC log due to the eventual consistency of Scylla. The problem could appear when a newer write reaches a replica before some older write. For a short period of time, when reading, it is possible for the replica to return only the newer write. The connector mitigates this problem by not reading a window of most recent changes (controlled by this parameter). Value expressed in milliseconds.|
+| `scylla.consistency.level` | The consistency level of CDC table read queries. This consistency level is used only for read queries to the CDC log table. By default, `QUORUM` level is used. |
+| `scylla.local.dc` | The name of Scylla local datacenter. This local datacenter name will be used to setup the connection to Scylla to prioritize sending requests to the nodes in the local datacenter. If not set, no particular datacenter will be prioritized. |
 
 ### Configuration for large Scylla clusters
 #### Offset (progress) storage

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <debezium.version>1.4.1.Final</debezium.version>
         <kafka.version>2.6.0</kafka.version>
         <scylla.driver.version>3.10.2-scylla-1</scylla.driver.version>
-        <scylla.cdc.java.version>1.1.0</scylla.cdc.java.version>
+        <scylla.cdc.java.version>1.2.0</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
     </properties>
 

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSessionBuilder.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSessionBuilder.java
@@ -16,6 +16,10 @@ public class ScyllaSessionBuilder {
         if (configuration.getUser() != null && configuration.getPassword() != null) {
             builder.withCredentials(configuration.getUser(), configuration.getPassword());
         }
+        builder.withConsistencyLevel(configuration.getConsistencyLevel());
+        if (configuration.getLocalDCName() != null) {
+            builder.withLocalDCName(configuration.getLocalDCName());
+        }
         return new Driver3Session(builder.build());
     }
 }


### PR DESCRIPTION
Add a configurable consistency level and local DC parameters. By default, consistency level is `QUORUM` and there is no local DC set.

Tested on a local 5 node Scylla cluster (2 nodes in dc1, 3 nodes in dc2) - both whether consistency level was correctly set and if correct local DC was used.

Fixes #3.