### PR TITLE
[DRAFT] Support for frozen collections and UDTs

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -158,6 +158,10 @@ public class ScyllaChangeRecordEmitter extends AbstractChangeRecordEmitter<Scyll
            return field.getList().stream().map(this::translateFieldToKafka).collect(Collectors.toList());
        }
 
+       if (dataType.getCqlType() == ChangeSchema.CqlType.SET) {
+           return field.getSet().stream().map(this::translateFieldToKafka).collect(Collectors.toList());
+       }
+
        return field.getAsObject();
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -185,6 +185,15 @@ public class ScyllaChangeRecordEmitter extends AbstractChangeRecordEmitter<Scyll
            return tupleStruct;
        }
 
+        if (dataType.getCqlType() == ChangeSchema.CqlType.UDT) {
+            Struct udtStruct = new Struct(ScyllaSchema.computeColumnSchema(dataType));
+            Map<String, Field> udt = field.getUDT();
+            udt.forEach((name, value) -> {
+                udtStruct.put(name, translateFieldToKafka(value));
+            });
+            return udtStruct;
+        }
+
        return field.getAsObject();
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -12,6 +12,8 @@ import org.apache.kafka.connect.data.Struct;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -160,6 +162,17 @@ public class ScyllaChangeRecordEmitter extends AbstractChangeRecordEmitter<Scyll
 
        if (dataType.getCqlType() == ChangeSchema.CqlType.SET) {
            return field.getSet().stream().map(this::translateFieldToKafka).collect(Collectors.toList());
+       }
+
+       if (dataType.getCqlType() == ChangeSchema.CqlType.MAP) {
+           Map<Field, Field> map = field.getMap();
+           Map<Object, Object> kafkaMap = new LinkedHashMap<>();
+           map.forEach((key, value) -> {
+               Object kafkaKey = translateFieldToKafka(key);
+               Object kafkaValue = translateFieldToKafka(value);
+               kafkaMap.put(kafkaKey, kafkaValue);
+           });
+           return kafkaMap;
        }
 
        return field.getAsObject();

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.data.Struct;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -173,6 +174,15 @@ public class ScyllaChangeRecordEmitter extends AbstractChangeRecordEmitter<Scyll
                kafkaMap.put(kafkaKey, kafkaValue);
            });
            return kafkaMap;
+       }
+
+       if (dataType.getCqlType() == ChangeSchema.CqlType.TUPLE) {
+           Struct tupleStruct = new Struct(ScyllaSchema.computeColumnSchema(dataType));
+           List<Field> tuple = field.getTuple();
+           for (int i = 0; i < tuple.size(); i++) {
+               tupleStruct.put("tuple_member_" + i, translateFieldToKafka(tuple.get(i)));
+           }
+           return tupleStruct;
        }
 
        return field.getAsObject();

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
@@ -72,7 +72,7 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
             if (cdef.getBaseTableColumnType() == ChangeSchema.ColumnType.PARTITION_KEY
                     || cdef.getBaseTableColumnType() == ChangeSchema.ColumnType.CLUSTERING_KEY) continue;
-            if (!isSupportedColumnSchema(cdef)) continue;
+            if (!isSupportedColumnSchema(changeSchema, cdef)) continue;
 
             Schema columnSchema = computeColumnSchema(cdef);
             Schema cellSchema = SchemaBuilder.struct()
@@ -89,7 +89,7 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
             if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.PARTITION_KEY
                     && cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.CLUSTERING_KEY) continue;
-            if (!isSupportedColumnSchema(cdef)) continue;
+            if (!isSupportedColumnSchema(changeSchema, cdef)) continue;
 
             Schema columnSchema = computeColumnSchema(cdef);
             keySchemaBuilder = keySchemaBuilder.field(cdef.getColumnName(), columnSchema);
@@ -102,7 +102,7 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         SchemaBuilder afterSchemaBuilder = SchemaBuilder.struct()
                 .name(adjuster.adjust(configuration.getLogicalName() + "." + collectionId.getTableName().keyspace + "." + collectionId.getTableName().name + ".After"));
         for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
-            if (!isSupportedColumnSchema(cdef)) continue;
+            if (!isSupportedColumnSchema(changeSchema, cdef)) continue;
 
             if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.PARTITION_KEY && cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.CLUSTERING_KEY) {
                 afterSchemaBuilder = afterSchemaBuilder.field(cdef.getColumnName(), cellSchemas.get(cdef.getColumnName()));
@@ -118,7 +118,7 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         SchemaBuilder beforeSchemaBuilder = SchemaBuilder.struct()
                 .name(adjuster.adjust(configuration.getLogicalName() + "." + collectionId.getTableName().keyspace + "." + collectionId.getTableName().name + ".Before"));
         for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
-            if (!isSupportedColumnSchema(cdef)) continue;
+            if (!isSupportedColumnSchema(changeSchema, cdef)) continue;
 
             if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.PARTITION_KEY && cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.CLUSTERING_KEY) {
                 beforeSchemaBuilder = beforeSchemaBuilder.field(cdef.getColumnName(), cellSchemas.get(cdef.getColumnName()));
@@ -131,7 +131,11 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
     }
 
     private Schema computeColumnSchema(ChangeSchema.ColumnDefinition cdef) {
-        switch (cdef.getCdcLogDataType().getCqlType()) {
+        return computeColumnSchema(cdef.getCdcLogDataType());
+    }
+
+    private Schema computeColumnSchema(ChangeSchema.DataType type) {
+        switch (type.getCqlType()) {
             case ASCII:
                 return Schema.OPTIONAL_STRING_SCHEMA;
             case BIGINT:
@@ -179,7 +183,10 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
                 return Schema.OPTIONAL_INT8_SCHEMA;
             case DURATION:
                 return Schema.OPTIONAL_STRING_SCHEMA;
-            case LIST:
+            case LIST: {
+                Schema innerSchema = computeColumnSchema(type.getTypeArguments().get(0));
+                return SchemaBuilder.array(innerSchema);
+            }
             case MAP:
             case SET:
             case UDT:
@@ -189,9 +196,19 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         }
     }
 
-    protected static boolean isSupportedColumnSchema(ChangeSchema.ColumnDefinition cdef) {
+    protected static boolean isSupportedColumnSchema(ChangeSchema changeSchema, ChangeSchema.ColumnDefinition cdef) {
         ChangeSchema.CqlType type = cdef.getCdcLogDataType().getCqlType();
-        return type != ChangeSchema.CqlType.LIST && type != ChangeSchema.CqlType.MAP &&
+        if (type == ChangeSchema.CqlType.LIST) {
+            // We only support frozen lists,
+            // (which can be identified by cdc$deleted_elements_ column).
+
+            // FIXME: When isFrozen is fixed in scylla-cdc-java (PR #60),
+            // replace with just a call to isFrozen.
+            String deletedElementsColumnName = "cdc$deleted_elements_" + cdef.getColumnName();
+            return changeSchema.getAllColumnDefinitions().stream()
+                    .noneMatch(c -> c.getColumnName().equals(deletedElementsColumnName));
+        }
+        return type != ChangeSchema.CqlType.MAP &&
                type != ChangeSchema.CqlType.SET && type != ChangeSchema.CqlType.UDT &&
                type != ChangeSchema.CqlType.TUPLE;
     }


### PR DESCRIPTION
Add support for including frozen collections in generated Kafka changes:

- frozen `MAP`
- frozen `LIST`
- frozen `SET`
- frozen UDTs
- tuples (at the moment, all tuples are frozen in Scylla)

Refs #9. 

This is just a draft PR. Things left to do:
- Finalize the representation of collections. For example, even though standard `SchemaBuilder.map` is used, maps are represented as arrays in JSONs. Similarly, maybe there is a neater way to represent tuples (instead of struct with `tuple_member_` fields). Finally, research whether such a format works well with other Sink Connectors.
- Additional testing. Only JSON converter was tested and it's very likely Avro does not work at the moment.
- Documentation (fix README, etc.)