### PR TITLE
Upgrades versions of several dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.2</version>
 
                 <configuration>
                     <descriptorRefs>
@@ -102,12 +102,70 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- highest compatible with java 8 -->
         <debezium.version>1.4.1.Final</debezium.version>
-        <kafka.version>2.6.0</kafka.version>
-        <scylla.driver.version>3.10.2-scylla-1</scylla.driver.version>
+        <!-- Docs claim java 8 supported, but support is deprecated -->
+        <kafka.version>3.3.1</kafka.version>
+        <scylla.driver.version>3.11.2.1</scylla.driver.version>
         <scylla.cdc.java.version>1.2.0</scylla.cdc.java.version>
-        <flogger.version>0.5.1</flogger.version>
+        <flogger.version>0.7.4</flogger.version>
+        <!-- added for transitive dependencies -->
+        <log4j.version>2.17.1</log4j.version>
+        <jackson-databind.version>2.13.4.1</jackson-databind.version>
+        <guava.version>24.1.1-jre</guava.version>
+        <jetty.version>11.0.2</jetty.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -129,6 +187,12 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
             <version>${debezium.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -167,6 +231,12 @@
                     <groupId>javax.jms</groupId>
                     <artifactId>jms</artifactId>
                 </exclusion>
+
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+
             </exclusions>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Direct dependencies:
kafka version changed from 2.6.0 to 3.3.1
scylla java driver version changed from 3.10.2-scylla-1 to 3.11.2.1 
flogger version changed from 0.5.1 to 0.7.4

Upgraded version requirements for transitive dependencies: 
org.apache.logging.log4:log4j set to 2.17.1
jackson-databind 2.13.4.1
guava 24.1.1-jre
jetty 11.0.2
snakeyaml 1.32

Excluded compile scope transitive dependencies on log4:log4j.

Additionally upgraded maven-assembly-plugin from 3.3.0 to 3.4.2

Main reason for dependency version upgrades is to appease CVE checker tools. This should deal with all critical and high severity level CVEs.