### PR TITLE
Remove debezium-embedded dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <guava.version>24.1.1-jre</guava.version>
         <jetty.version>11.0.2</jetty.version>
         <snakeyaml.version>1.32</snakeyaml.version>
+        <commons.version>3.8.1</commons.version>
     </properties>
 
     <dependencyManagement>
@@ -184,15 +185,14 @@
             <version>${debezium.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-embedded</artifactId>
-            <version>${debezium.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Remove debezium-embedded dependency for a few reasons:

1. It's deprecated by Debezium
2. One of it's dependencies (`org.eclipse.jetty:jetty-server`) had CVE-2022-2191 vulnerability
3. It was unused

After removing this dependency, `ConfigSerializerUtil` class stopped compiling. Added back `commons-lang3` and `connect-transforms` transitive dependencies (which are not affected by CVE-2022-2191).