### PR TITLE
Adjust flogger.backend_factory property

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
@@ -35,7 +35,7 @@ public class ScyllaConnector extends SourceConnector {
         // to log4j.
         System.setProperty(
                 "flogger.backend_factory",
-                "com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance");
+                "com.google.common.flogger.backend.log4j.Log4jBackendFactory");
     }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
After the change to 0.7.4 the `#getInstance` part should have been removed. Fixes #29.