### PR TITLE
Logging workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>3.3.1</kafka.version>
         <scylla.driver.version>3.11.2.1</scylla.driver.version>
-        <scylla.cdc.java.version>1.2.3-REPLACE-WITH-UNSHADED-VERSION</scylla.cdc.java.version>
+        <scylla.cdc.java.version>1.3.0</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.17.1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>3.3.1</kafka.version>
         <scylla.driver.version>3.11.2.1</scylla.driver.version>
-        <scylla.cdc.java.version>1.2.1</scylla.cdc.java.version>
-        <flogger.version>0.7.4</flogger.version>
+        <scylla.cdc.java.version>1.2.3-REPLACE-WITH-UNSHADED-VERSION</scylla.cdc.java.version>
+        <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.17.1</log4j.version>
         <jackson-databind.version>2.13.4.1</jackson-databind.version>
@@ -128,6 +128,21 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-web</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
@@ -164,6 +179,21 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.flogger</groupId>
+                <artifactId>flogger</artifactId>
+                <version>${flogger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.flogger</groupId>
+                <artifactId>flogger-system-backend</artifactId>
+                <version>${flogger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.flogger</groupId>
+                <artifactId>flogger-log4j-backend</artifactId>
+                <version>${flogger.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -210,7 +240,6 @@
         <dependency>
             <groupId>com.google.flogger</groupId>
             <artifactId>flogger-log4j-backend</artifactId>
-            <version>${flogger.version}</version>
             <exclusions>
                 <!--
                 This is a known (not fixed) problem, that


### PR DESCRIPTION
Changes flogger version back to 0.5.1 to be extra safe. Requires scylla-cdc-java to be fixed.
That means its logging components are not shaded.
After this change there should be no ClassCastExceptions or NoSuchMethodExceptions.