### PR TITLE
Add configuration field for minimalWaitForWindow in driver

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -139,6 +139,17 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
             .withValidation(Field::isNonNegativeInteger)
             .withDefault(30000);
 
+    public static final Field MINIMAL_WAIT_FOR_WINDOW_MS = Field.create("scylla.minimal.wait.for.window.time")
+        .withDisplayName("Minimal 'waitForWindow' time (ms)")
+        .withType(ConfigDef.Type.INT)
+        .withWidth(ConfigDef.Width.MEDIUM)
+        .withImportance(ConfigDef.Importance.LOW)
+        .withDescription("Minimal time between reading consecutive CDC log windows. Meant to be used as a simple throttling mechanism " +
+            "in situations where driver has a lot of old data to catch up on and ends up hogging resources. " +
+            "Value expressed in milliseconds.")
+        .withValidation(Field::isNonNegativeInteger)
+        .withDefault(0);
+
     public static final CQLConfiguration.ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = CQLConfiguration.ConsistencyLevel.QUORUM;
     public static final Field CONSISTENCY_LEVEL = Field.create("scylla.consistency.level")
             .withDisplayName("Consistency Level")
@@ -292,7 +303,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
             CommonConnectorConfig.CONFIG_DEFINITION.edit()
                     .name("Scylla")
                     .type(CLUSTER_IP_ADDRESSES, USER, PASSWORD, TOPIC_PREFIX, CONSISTENCY_LEVEL, QUERY_OPTIONS_FETCH_SIZE, LOCAL_DC_NAME, SSL_ENABLED, SSL_PROVIDER, SSL_TRUSTSTORE_PATH, SSL_TRUSTSTORE_PASSWORD, SSL_KEYSTORE_PATH, SSL_KEYSTORE_PASSWORD,SSL_CIPHER_SUITES, SSL_OPENSLL_KEYCERTCHAIN, SSL_OPENSLL_PRIVATEKEY)
-                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE, PREIMAGES_ENABLED, RETRY_BACKOFF_BASE_MS, RETRY_MAX_BACKOFF_MS, RETRY_BACKOFF_JITTER_PERCENTAGE, POOLING_CORE_POOL_LOCAL, POOLING_MAX_POOL_LOCAL, POOLING_MAX_REQUESTS_PER_CONNECTION, POOLING_MAX_QUEUE_SIZE, POOLING_POOL_TIMEOUT_MS)
+                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE, MINIMAL_WAIT_FOR_WINDOW_MS, PREIMAGES_ENABLED, RETRY_BACKOFF_BASE_MS, RETRY_MAX_BACKOFF_MS, RETRY_BACKOFF_JITTER_PERCENTAGE, POOLING_CORE_POOL_LOCAL, POOLING_MAX_POOL_LOCAL, POOLING_MAX_REQUESTS_PER_CONNECTION, POOLING_MAX_QUEUE_SIZE, POOLING_POOL_TIMEOUT_MS)
                     .events(TABLE_NAMES)
                     .excluding(Heartbeat.HEARTBEAT_INTERVAL).events(CUSTOM_HEARTBEAT_INTERVAL)
                     // Exclude some Debezium options, which are not applicable/not supported by
@@ -378,6 +389,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
 
     public long getConfidenceWindowSizeMs() {
         return config.getInteger(ScyllaConnectorConfig.CONFIDENCE_WINDOW_SIZE);
+    }
+
+    public long getMinimalWaitForWindowMs() {
+        return config.getInteger(ScyllaConnectorConfig.MINIMAL_WAIT_FOR_WINDOW_MS);
     }
 
     public long getHeartbeatIntervalMs() {

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -47,6 +47,7 @@ public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSou
                 .withQueryTimeWindowSizeMs(configuration.getQueryTimeWindowSizeMs())
                 .withConfidenceWindowSizeMs(configuration.getConfidenceWindowSizeMs())
                 .withWorkerRetryBackoff(retryBackoff)
+                .withMinimalWaitForWindowMs(configuration.getMinimalWaitForWindowMs())
                 .build();
         Worker worker = new Worker(workerConfiguration);
         try {


### PR DESCRIPTION
This config allows for configuring minimal time between reading consecutive CDC log windows. Meant to be used as a simple throttling mechanism in situations where driver has a lot of old data to catch up on and ends up hogging resources.