### PR TITLE
Preimage support

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
@@ -1,5 +1,6 @@
 package com.scylladb.cdc.debezium.connector;
 
+import com.scylladb.cdc.model.TaskId;
 import com.scylladb.cdc.model.worker.ChangeSchema;
 import com.scylladb.cdc.model.worker.RawChange;
 import com.scylladb.cdc.model.worker.Task;
@@ -9,6 +10,8 @@ import io.debezium.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
@@ -18,17 +21,31 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
     private final ScyllaOffsetContext offsetContext;
     private final ScyllaSchema schema;
     private final Clock clock;
+    private final boolean usePreimages;
+    private final Map<TaskId, RawChange> lastPreImage;
 
-    public ScyllaChangesConsumer(EventDispatcher<CollectionId> dispatcher, ScyllaOffsetContext offsetContext, ScyllaSchema schema, Clock clock) {
+    public ScyllaChangesConsumer(EventDispatcher<CollectionId> dispatcher, ScyllaOffsetContext offsetContext, ScyllaSchema schema, Clock clock, boolean usePreimages) {
         this.dispatcher = dispatcher;
         this.offsetContext = offsetContext;
         this.schema = schema;
         this.clock = clock;
+        this.usePreimages = usePreimages;
+        if (usePreimages) {
+            this.lastPreImage = new HashMap<>();
+        } else {
+            this.lastPreImage = null;
+        }
     }
 
     @Override
     public CompletableFuture<Void> consume(Task task, RawChange change) {
         try {
+            logger.trace("Consuming RawChange of type {}", change.getOperationType());
+            if (usePreimages && change.getOperationType() == RawChange.OperationType.PRE_IMAGE) {
+                lastPreImage.put(task.id, change);
+                return CompletableFuture.completedFuture(null);
+            }
+
             Task updatedTask = task.updateState(change.getId());
             TaskStateOffsetContext taskStateOffsetContext = offsetContext.taskStateOffsetContext(task.id);
             taskStateOffsetContext.dataChangeEvent(updatedTask.state);
@@ -55,8 +72,15 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
                 return CompletableFuture.completedFuture(null);
             }
 
-            dispatcher.dispatchDataChangeEvent(new CollectionId(task.id.getTable()),
+            if (usePreimages && lastPreImage.containsKey(task.id)) {
+                dispatcher.dispatchDataChangeEvent(new CollectionId(task.id.getTable()),
+                    new ScyllaChangeRecordEmitter(lastPreImage.get(task.id), change, taskStateOffsetContext, schema, clock));
+                lastPreImage.remove(task.id);
+            }
+            else {
+                dispatcher.dispatchDataChangeEvent(new CollectionId(task.id.getTable()),
                     new ScyllaChangeRecordEmitter(change, taskStateOffsetContext, schema, clock));
+            }
         } catch (InterruptedException e) {
             logger.error("Exception while dispatching change: {}", change.getId().toString());
             logger.error("Exception details: {}", e.getMessage());

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -165,6 +165,17 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
                     "the connection to Scylla to prioritize sending requests to " +
                     "the nodes in the local datacenter. If not set, no particular datacenter will be prioritized.");
 
+    public static final Field PREIMAGES_ENABLED = Field.create("experimental.preimages.enabled")
+        .withDisplayName("Enable experimental preimages support")
+        .withType(ConfigDef.Type.BOOLEAN)
+        .withWidth(ConfigDef.Width.MEDIUM)
+        .withImportance(ConfigDef.Importance.LOW)
+        .withDefault(false)
+        .withDescription("If enabled connector will use PRE_IMAGE CDC entries to populate 'before' field of the " +
+            "debezium Envelope of the next kafka message. This may change some expected behaviours (e.g. ROW_DELETE " +
+            "will use preimage instead of its own information). See Scylla docs for more information about CDC " +
+            "preimages limitations. ");
+
     /*
      * Scylla CDC Source Connector relies on heartbeats to move the offset,
      * because the offset determines if the generation ended, therefore HEARTBEAT_INTERVAL
@@ -182,7 +193,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
             CommonConnectorConfig.CONFIG_DEFINITION.edit()
                     .name("Scylla")
                     .type(CLUSTER_IP_ADDRESSES, USER, PASSWORD, LOGICAL_NAME, CONSISTENCY_LEVEL, LOCAL_DC_NAME, SSL_ENABLED, SSL_PROVIDER, SSL_TRUSTSTORE_PATH, SSL_TRUSTSTORE_PASSWORD, SSL_KEYSTORE_PATH, SSL_KEYSTORE_PASSWORD,SSL_CIPHER_SUITES, SSL_OPENSLL_KEYCERTCHAIN, SSL_OPENSLL_PRIVATEKEY)
-                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE)
+                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE, PREIMAGES_ENABLED)
                     .events(TABLE_NAMES)
                     .excluding(Heartbeat.HEARTBEAT_INTERVAL).events(CUSTOM_HEARTBEAT_INTERVAL)
                     // Exclude some Debezium options, which are not applicable/not supported by
@@ -285,6 +296,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
 
     public String getLocalDCName() {
         return config.getString(ScyllaConnectorConfig.LOCAL_DC_NAME);
+    }
+
+    public boolean getPreimagesEnabled() {
+        return config.getBoolean(ScyllaConnectorConfig.PREIMAGES_ENABLED);
     }
 
     @Override

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -43,7 +43,7 @@ public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSou
         Driver3Session session = new ScyllaSessionBuilder(configuration).build();
         Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
         ScyllaWorkerTransport workerTransport = new ScyllaWorkerTransport(context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
-        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock);
+        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock, configuration.getPreimagesEnabled());
         WorkerConfiguration workerConfiguration = WorkerConfiguration.builder()
                 .withTransport(workerTransport)
                 .withCQL(cql)


### PR DESCRIPTION
Adds an option to enable preimage support. Connector with said support enabled will
use PRE_IMAGE operation type RawChanges to fill 'before' field of debezium Envelopes of other types of changes.

If enabled ScyllaChangesConsumer will now remember last PRE_IMAGE type RawChange for each distinct TaskId.
Upon encountering next supported non-preimage operation the consumer will use remembered preimage and clear
the 'cache' for that TaskId.