### PR TITLE
Add daily vulnerability scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,24 @@
+name: Vulnerability scan
+
+on:
+  schedule:
+    cron: "43 16 * * *"
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Trivy fs scan
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run trivy in fs mode
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'table'
+        exit-code: '1'
+        ignore-unfixed: false
+        severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
This workflow will run trivy fs scan every day around 16:43 UTC time. Severities below MEDIUM and UNKNOWN will be ignored.