### PR TITLE
Bump snappy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
                 <artifactId>netty-handler</artifactId>
                 <version>4.1.100.Final</version>
             </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Sets snappy-java version to 1.1.10.5
Relevant part of dependency tree now looks like this:
 +- org.apache.kafka:connect-api:jar:3.3.1:compile
 |  +- org.apache.kafka:kafka-clients:jar:3.3.1:compile
 |  |  +- com.github.luben:zstd-jni:jar:1.5.2-1:runtime
 |  |  +- org.lz4:lz4-java:jar:1.8.0:runtime
 |  |  \- org.xerial.snappy:snappy-java:jar:1.1.10.5:runtime
 |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:runtime