### PR TITLE
Refactor Connector semantics

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -51,6 +51,9 @@ public class ScyllaChangeRecordEmitter extends AbstractChangeRecordEmitter<Scyll
             case ROW_UPDATE:
                 return Envelope.Operation.UPDATE;
             case ROW_INSERT:
+            // TODO: Postimages always generate some delta as part of an operation.
+            //       Use the right envelope to its corresponding delta.
+            case POST_IMAGE:
                 return Envelope.Operation.CREATE;
             case PARTITION_DELETE: // See comment in ScyllaChangesConsumer on the support of partition deletes.
             case ROW_DELETE:

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -185,6 +185,17 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
         .withDescription("If enabled connector will use PRE_IMAGE CDC entries to populate 'before' field of the " +
             "debezium Envelope of the next kafka message.");
 
+    public static final Field POSTIMAGES_ENABLED = Field.create("postimages.enabled")
+            .withDisplayName("Enable postimages support")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDefault(false)
+            .withDescription("Whether the connector should ignore insert and update deltas and consume PostImage " +
+                    "events instead. PostImages only get generated for rows modified as part of an UPDATE or INSERT " +
+                    "statement. Only relevant when `'postimage': 'true'`, otherwise this option simply disables the " +
+                    "consumption of deltas.");
+
     /*
      * Scylla CDC Source Connector relies on heartbeats to move the offset,
      * because the offset determines if the generation ended, therefore HEARTBEAT_INTERVAL
@@ -202,7 +213,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
             CommonConnectorConfig.CONFIG_DEFINITION.edit()
                     .name("Scylla")
                     .type(CLUSTER_IP_ADDRESSES, USER, PASSWORD, LOGICAL_NAME, CONSISTENCY_LEVEL, QUERY_OPTIONS_FETCH_SIZE, LOCAL_DC_NAME, SSL_ENABLED, SSL_PROVIDER, SSL_TRUSTSTORE_PATH, SSL_TRUSTSTORE_PASSWORD, SSL_KEYSTORE_PATH, SSL_KEYSTORE_PASSWORD,SSL_CIPHER_SUITES, SSL_OPENSLL_KEYCERTCHAIN, SSL_OPENSLL_PRIVATEKEY)
-                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE, PREIMAGES_ENABLED)
+                    .connector(QUERY_TIME_WINDOW_SIZE, CONFIDENCE_WINDOW_SIZE, PREIMAGES_ENABLED, POSTIMAGES_ENABLED)
                     .events(TABLE_NAMES)
                     .excluding(Heartbeat.HEARTBEAT_INTERVAL).events(CUSTOM_HEARTBEAT_INTERVAL)
                     // Exclude some Debezium options, which are not applicable/not supported by
@@ -309,6 +320,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
 
     public boolean getPreimagesEnabled() {
         return config.getBoolean(ScyllaConnectorConfig.PREIMAGES_ENABLED);
+    }
+
+    public boolean getPostimagesEnabled() {
+        return config.getBoolean(ScyllaConnectorConfig.POSTIMAGES_ENABLED);
     }
 
     public int getQueryOptionsFetchSize() {

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -176,16 +176,14 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
                     "the connection to Scylla to prioritize sending requests to " +
                     "the nodes in the local datacenter. If not set, no particular datacenter will be prioritized.");
 
-    public static final Field PREIMAGES_ENABLED = Field.create("experimental.preimages.enabled")
-        .withDisplayName("Enable experimental preimages support")
+    public static final Field PREIMAGES_ENABLED = Field.create("preimages.enabled")
+        .withDisplayName("Enable preimages support")
         .withType(ConfigDef.Type.BOOLEAN)
         .withWidth(ConfigDef.Width.MEDIUM)
         .withImportance(ConfigDef.Importance.LOW)
         .withDefault(false)
         .withDescription("If enabled connector will use PRE_IMAGE CDC entries to populate 'before' field of the " +
-            "debezium Envelope of the next kafka message. This may change some expected behaviours (e.g. ROW_DELETE " +
-            "will use preimage instead of its own information). See Scylla docs for more information about CDC " +
-            "preimages limitations. ");
+            "debezium Envelope of the next kafka message.");
 
     /*
      * Scylla CDC Source Connector relies on heartbeats to move the offset,

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -43,7 +43,7 @@ public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSou
         Driver3Session session = new ScyllaSessionBuilder(configuration).build();
         Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
         ScyllaWorkerTransport workerTransport = new ScyllaWorkerTransport(context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
-        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock, configuration.getPreimagesEnabled());
+        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock, configuration.getPreimagesEnabled(), configuration.getPostimagesEnabled());
         WorkerConfiguration workerConfiguration = WorkerConfiguration.builder()
                 .withTransport(workerTransport)
                 .withCQL(cql)

--- a/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ScyllaExtractNewRecordState.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ScyllaExtractNewRecordState.java
@@ -1,23 +1,50 @@
 package com.scylladb.cdc.debezium.connector.transforms;
 
+import java.util.Map;
+import io.debezium.data.Envelope;
 import io.debezium.transforms.ExtractNewRecordState;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DeleteHandling;
 
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.ConfigDef;
+
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.util.SchemaUtil;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Struct;
 
 public class ScyllaExtractNewRecordState<R extends ConnectRecord<R>> extends ExtractNewRecordState<R> {
-    private Cache<Schema, Schema> schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+    private Cache<Integer, Schema> schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+    private DeleteHandling handleDeletes;
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+    }
+
 
     @Override
     public R apply(final R record) {
+        // Debezium by default does not emit a rewrite (delete.handling.mode)
+        // when an after field is present. However, in ScyllaDB, we represent
+        // the affected keys in the after field.
+        boolean isDelete = false;
+        boolean hasRewrite = false;
+
+        if (record != null && (record.value() instanceof Struct) && record instanceof SourceRecord) {
+            final SourceRecord sr = (SourceRecord) record;
+                 if (Envelope.operationFor(sr) == Envelope.Operation.DELETE) {
+                     isDelete = true;
+                 }
+        }
+
         final R ret = super.apply(record);
         if (ret == null || !(ret.value() instanceof Struct)) {
             return ret;
@@ -25,21 +52,33 @@ public class ScyllaExtractNewRecordState<R extends ConnectRecord<R>> extends Ext
 
         final Struct value = (Struct)ret.value();
 
-        Schema updatedSchema = schemaUpdateCache.get(value.schema());
+        int schemaKey = getSchemaKey(value);
+
+        Schema updatedSchema = schemaUpdateCache.get(schemaKey);
         if (updatedSchema == null) {
-            updatedSchema = makeUpdatedSchema(value.schema());
-            schemaUpdateCache.put(value.schema(), updatedSchema);
+            updatedSchema = makeUpdatedSchema(value.schema(), value);
+            schemaUpdateCache.put(schemaKey, updatedSchema);
         }
 
         final Struct updatedValue = new Struct(updatedSchema);
 
         for (Field field : value.schema().fields()) {
+            if (isDroppableField(field, value)) {
+                continue;
+            }
+
             if (isSimplifiableField(field)) {
                 Struct fieldValue = (Struct) value.get(field);
                 updatedValue.put(field.name(), fieldValue == null ? null : fieldValue.get("value"));
             } else {
                 updatedValue.put(field.name(), value.get(field));
             }
+        }
+
+    if (isDelete) {
+           if (handleDeletes == DeleteHandling.REWRITE) {
+                updatedValue.put(ExtractNewRecordStateConfigDefinition.DELETED_FIELD, "true");
+       }
         }
 
         return ret.newRecord(ret.topic(), ret.kafkaPartition(), ret.keySchema(), ret.key(), updatedSchema, updatedValue, ret.timestamp());
@@ -49,6 +88,43 @@ public class ScyllaExtractNewRecordState<R extends ConnectRecord<R>> extends Ext
     public void close() {
         super.close();
         schemaUpdateCache = null;
+    }
+
+    // getSchemaKey computes a unique schema according to the payload values
+    // This ensures different values are stored with different keys in the LRU cache.
+    private int getSchemaKey(Struct value) {
+       Schema schema = value.schema();
+       final int prime = 31;
+       int hash = 1;
+
+       hash += prime * hash + (schema.name() == null ? 0 : schema.name().hashCode());
+
+       for (Field field : schema.fields()) {
+            hash = prime * hash + field.name().hashCode();
+
+            Object fieldValue = value.get(field);
+            boolean isNull = fieldValue == null;
+            hash = prime * hash + (isNull ? 0 : 1);
+
+            if (!isNull && field.schema().type() == Type.STRUCT) {
+                 hash = prime * hash + field.schema().type().hashCode();
+            }
+       }
+
+       return hash;
+    }
+
+    // isDroppableField drops null Struct values within a Field. It does NOT drops empty Structs representing an actual delta mutation.
+    // This allow subscribers to upsert deltas and converge to a stable result. For example, the following Type/Values will return:
+    // False (don't drop) -- Type: STRUCT Value: Struct{}
+    // True (drop)        -- Type: STRUCT Value: null
+    private boolean isDroppableField(Field field, Struct value) {
+        if (field.schema().type() == Type.STRUCT
+            && (value.get(field) == null)) {
+            return field.schema().isOptional();
+        }
+
+        return false;
     }
 
     private boolean isSimplifiableField(Field field) {
@@ -64,10 +140,14 @@ public class ScyllaExtractNewRecordState<R extends ConnectRecord<R>> extends Ext
         return true;
     }
 
-    private Schema makeUpdatedSchema(Schema schema) {
+    private Schema makeUpdatedSchema(Schema schema, Struct value) {
         final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
 
         for (Field field : schema.fields()) {
+            if (isDroppableField(field, value)) {
+              continue;
+            }
+
             if (isSimplifiableField(field)) {
                 builder.field(field.name(), field.schema().field("value").schema());
             } else {


### PR DESCRIPTION
This series implements proper connector semantics going forward. 

After this series:

- DELETE operations exclusively use the after Field.
- preImages exclusively use the before Field.
- The `ScyllaExtractNewState` SMT can be used both with preImages/postImages and Deltas enabled (it is now dynamic)
- Consumers using the `ScyllaExtractNewState` must implement an `UPSERT` mode when consuming from ScyllaDB deltas only (Apache Pinot and Elasticsearch are some examples of datastores supporting these modes), whereas postImage operations should rely on `FULL` (or equivalent) mode.
- We promote preImages to production ready.

Breaking change, existing consumers may require changes.

Tested with Apache Pinot in `FULL` mode (postImages and preImages), and Elasticsearch in `UPSERT`mode.