### PR TITLE
Bump netty dependencies to 4.1.119.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.115.Final</version>
+                <version>4.1.119.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.100.Final</version>
+                <version>4.1.119.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
Takes care of CVE-2025-25193, CVE-2025-24970 warnings.