### PR TITLE
Debezium upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <!-- highest compatible with java 8 -->
-        <debezium.version>1.4.1.Final</debezium.version>
+        <debezium.version>2.6.2.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>3.3.1</kafka.version>
         <scylla.driver.version>3.11.5.3</scylla.driver.version>

--- a/src/main/java/com/scylladb/cdc/debezium/connector/CollectionId.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/CollectionId.java
@@ -1,8 +1,11 @@
 package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.model.TableName;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
+import io.debezium.util.Collect;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class CollectionId implements DataCollectionId {
@@ -16,6 +19,21 @@ public class CollectionId implements DataCollectionId {
     @Override
     public String identifier() {
         return tableName.keyspace + "." + tableName.name;
+    }
+
+    @Override
+    public List<String> parts() {
+        return Collect.arrayListOf(tableName.keyspace, tableName.name);
+    }
+
+    @Override
+    public List<String> databaseParts() {
+        return Collect.arrayListOf(tableName.keyspace, tableName.name);
+    }
+
+    @Override
+    public List<String> schemaParts() {
+        return Collections.emptyList();
     }
 
     public TableName getTableName() {

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeEventSourceFactory.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeEventSourceFactory.java
@@ -1,6 +1,7 @@
 package com.scylladb.cdc.debezium.connector;
 
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
@@ -8,15 +9,17 @@ import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.util.Clock;
 
-public class ScyllaChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class ScyllaChangeEventSourceFactory implements ChangeEventSourceFactory<ScyllaPartition, ScyllaOffsetContext> {
 
     private final ScyllaConnectorConfig configuration;
     private final ScyllaTaskContext taskContext;
     private final ScyllaSchema schema;
-    private final EventDispatcher<CollectionId> dispatcher;
+    private final EventDispatcher<ScyllaPartition, CollectionId> dispatcher;
     private final Clock clock;
 
-    public ScyllaChangeEventSourceFactory(ScyllaConnectorConfig configuration, ScyllaTaskContext context, ScyllaSchema schema, EventDispatcher<CollectionId> dispatcher, Clock clock) {
+    public ScyllaChangeEventSourceFactory(ScyllaConnectorConfig configuration, ScyllaTaskContext context,
+                                          ScyllaSchema schema,
+                                          EventDispatcher<ScyllaPartition, CollectionId> dispatcher, Clock clock) {
         this.configuration = configuration;
         this.taskContext = context;
         this.schema = schema;
@@ -25,12 +28,12 @@ public class ScyllaChangeEventSourceFactory implements ChangeEventSourceFactory 
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new ScyllaSnapshotChangeEventSource(configuration, (ScyllaOffsetContext) offsetContext, snapshotProgressListener);
+    public SnapshotChangeEventSource<ScyllaPartition, ScyllaOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<ScyllaPartition> snapshotProgressListener, NotificationService<ScyllaPartition, ScyllaOffsetContext> notificationService) {
+        return new ScyllaSnapshotChangeEventSource(configuration, snapshotProgressListener, notificationService);
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
-        return new ScyllaStreamingChangeEventSource(configuration, taskContext, (ScyllaOffsetContext) offsetContext, schema, dispatcher, clock);
+    public StreamingChangeEventSource<ScyllaPartition, ScyllaOffsetContext> getStreamingChangeEventSource() {
+        return new ScyllaStreamingChangeEventSource(configuration, taskContext, schema, dispatcher, clock);
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaCollectionSchema.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaCollectionSchema.java
@@ -1,7 +1,7 @@
 package com.scylladb.cdc.debezium.connector;
 
 import io.debezium.data.Envelope;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.schema.DataCollectionSchema;
 import org.apache.kafka.connect.data.Schema;
 

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaErrorHandler.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaErrorHandler.java
@@ -4,7 +4,7 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 
 public class ScyllaErrorHandler extends ErrorHandler {
-    public ScyllaErrorHandler(String logicalName, ChangeEventQueue<?> queue) {
-        super(ScyllaConnector.class, logicalName, queue);
+    public ScyllaErrorHandler(ScyllaConnectorConfig scyllaConnectorConfig, ChangeEventQueue<?> queue, ErrorHandler replacedErrorHandler) {
+        super(ScyllaConnector.class, scyllaConnectorConfig, queue, replacedErrorHandler);
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaEventMetadataProvider.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaEventMetadataProvider.java
@@ -2,7 +2,7 @@ package com.scylladb.cdc.debezium.connector;
 
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
 import org.apache.kafka.connect.data.Struct;
 
 import java.time.Instant;

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaInconsistentSchemaHandler.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaInconsistentSchemaHandler.java
@@ -7,9 +7,9 @@ import io.debezium.schema.DataCollectionSchema;
 
 import java.util.Optional;
 
-public class ScyllaInconsistentSchemaHandler implements EventDispatcher.InconsistentSchemaHandler<CollectionId> {
+public class ScyllaInconsistentSchemaHandler implements EventDispatcher.InconsistentSchemaHandler<ScyllaPartition, CollectionId> {
     @Override
-    public Optional<DataCollectionSchema> handle(CollectionId collectionId, ChangeRecordEmitter changeRecordEmitter) {
+    public Optional<DataCollectionSchema> handle(ScyllaPartition partition, CollectionId collectionId, ChangeRecordEmitter changeRecordEmitter) {
         ScyllaChangeRecordEmitter scyllaChangeRecordEmitter = (ScyllaChangeRecordEmitter) changeRecordEmitter;
         RawChange change = scyllaChangeRecordEmitter.getChange();
         ScyllaSchema scyllaSchema = scyllaChangeRecordEmitter.getSchema();

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaOffsetContext.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaOffsetContext.java
@@ -1,9 +1,12 @@
 package com.scylladb.cdc.debezium.connector;
 
+import com.google.common.collect.ImmutableMap;
 import com.scylladb.cdc.model.TaskId;
+import io.debezium.connector.SnapshotRecord;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
 import io.debezium.pipeline.txmetadata.TransactionContext;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
@@ -24,10 +27,10 @@ public class ScyllaOffsetContext implements OffsetContext {
         return new TaskStateOffsetContext(this, sourceInfos.get(taskId));
     }
 
-    @Override
-    public Map<String, ?> getPartition() {
-        // See TaskStateOffsetContext
-        throw new UnsupportedOperationException();
+    public Offsets<ScyllaPartition, TaskStateOffsetContext> toDebeziumOffsets() {
+        ImmutableMap.Builder<ScyllaPartition, TaskStateOffsetContext> builder = new ImmutableMap.Builder<ScyllaPartition, TaskStateOffsetContext>();
+        sourceInfos.values().forEach(sourceInfo -> builder.put(new ScyllaPartition(this, sourceInfo), new TaskStateOffsetContext(this, sourceInfo)));
+        return Offsets.of(builder.build());
     }
 
     @Override
@@ -54,7 +57,7 @@ public class ScyllaOffsetContext implements OffsetContext {
     }
 
     @Override
-    public void markLastSnapshotRecord() {
+    public void markSnapshotRecord(SnapshotRecord snapshotRecord) {
 
     }
 

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaPartition.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaPartition.java
@@ -1,0 +1,21 @@
+package com.scylladb.cdc.debezium.connector;
+
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.util.Collect;
+
+import java.util.Map;
+
+public class ScyllaPartition implements Partition {
+  private final ScyllaOffsetContext scyllaOffsetContext;
+  private final SourceInfo sourceInfo;
+
+  public ScyllaPartition(ScyllaOffsetContext scyllaOffsetContext, SourceInfo sourceInfo) {
+    this.scyllaOffsetContext = scyllaOffsetContext;
+    this.sourceInfo = sourceInfo;
+  }
+
+  @Override
+  public Map<String, String> getSourcePartition() {
+    return sourceInfo.partition();
+  }
+}

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
@@ -5,7 +5,7 @@ import io.debezium.data.Envelope;
 import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.schema.DataCollectionSchema;
 import io.debezium.schema.DatabaseSchema;
-import io.debezium.util.SchemaNameAdjuster;
+import io.debezium.schema.SchemaNameAdjuster;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -22,7 +22,7 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
 
     private final Schema sourceSchema;
     private final ScyllaConnectorConfig configuration;
-    private final SchemaNameAdjuster adjuster = SchemaNameAdjuster.create(LOGGER);
+    private final SchemaNameAdjuster adjuster = SchemaNameAdjuster.create();
     private final Map<CollectionId, ScyllaCollectionSchema> dataCollectionSchemas = new HashMap<>();
     private final Map<CollectionId, ChangeSchema> changeSchemas = new HashMap<>();
 
@@ -60,6 +60,8 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
                 .field(Envelope.FieldName.OPERATION, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(Envelope.FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
                 .field(Envelope.FieldName.TRANSACTION, TransactionMonitor.TRANSACTION_BLOCK_SCHEMA)
+                .field(Envelope.FieldName.TIMESTAMP_US, Schema.OPTIONAL_INT64_SCHEMA)
+                .field(Envelope.FieldName.TIMESTAMP_NS, Schema.OPTIONAL_INT64_SCHEMA)
                 .build();
 
         final Envelope envelope = Envelope.fromSchema(valueSchema);
@@ -204,6 +206,11 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
 
     @Override
     public boolean tableInformationComplete() {
+        return false;
+    }
+
+    @Override
+    public boolean isHistorized() {
         return false;
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSourceInfoStructMaker.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSourceInfoStructMaker.java
@@ -1,22 +1,21 @@
 package com.scylladb.cdc.debezium.connector;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 public class ScyllaSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
+    private Schema schema;
 
-    private static final String TS_US = "ts_us";
-    private final Schema schema;
-
-    public ScyllaSourceInfoStructMaker(String connector, String version, CommonConnectorConfig connectorConfig) {
-        super(connector, version, connectorConfig);
+    @Override
+    public void init(String connector, String version, CommonConnectorConfig connectorConfig) {
+        super.init(connector, version, connectorConfig);
         schema = commonSchemaBuilder()
                 .name("com.scylladb.cdc.debezium.connector")
                 .field(SourceInfo.KEYSPACE_NAME, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME, Schema.STRING_SCHEMA)
-                .field(TS_US, Schema.INT64_SCHEMA)
                 .build();
     }
 
@@ -30,6 +29,6 @@ public class ScyllaSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
         return super.commonStruct(sourceInfo)
                 .put(SourceInfo.KEYSPACE_NAME, sourceInfo.getTableName().keyspace)
                 .put(SourceInfo.TABLE_NAME, sourceInfo.getTableName().name)
-                .put(TS_US, sourceInfo.timestampUs());
+                .put(AbstractSourceInfo.TIMESTAMP_US_KEY, sourceInfo.timestampUs());
     }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -2,36 +2,30 @@ package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.cql.driver3.Driver3Session;
 import com.scylladb.cdc.cql.driver3.Driver3WorkerCQL;
-import com.scylladb.cdc.model.ExponentialRetryBackoffWithJitter;
-import com.scylladb.cdc.model.RetryBackoff;
-import com.scylladb.cdc.model.worker.WorkerConfiguration;
 import com.scylladb.cdc.model.worker.Worker;
+import com.scylladb.cdc.model.worker.WorkerConfiguration;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.util.Clock;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.sql.Driver;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSource {
+public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSource<ScyllaPartition, ScyllaOffsetContext> {
     private final ScyllaConnectorConfig configuration;
     private ScyllaTaskContext taskContext;
-    private final ScyllaOffsetContext offsetContext;
     private final ScyllaSchema schema;
-    private final EventDispatcher<CollectionId> dispatcher;
+    private final EventDispatcher<ScyllaPartition, CollectionId> dispatcher;
     private final Clock clock;
     private final Duration pollInterval;
 
-    public ScyllaStreamingChangeEventSource(ScyllaConnectorConfig configuration, ScyllaTaskContext taskContext, ScyllaOffsetContext offsetContext, ScyllaSchema schema, EventDispatcher<CollectionId> dispatcher, Clock clock) {
+    public ScyllaStreamingChangeEventSource(ScyllaConnectorConfig configuration, ScyllaTaskContext taskContext,
+                                            ScyllaSchema schema,
+                                            EventDispatcher<ScyllaPartition, CollectionId> dispatcher, Clock clock) {
         this.configuration = configuration;
         this.taskContext = taskContext;
-        this.offsetContext = offsetContext;
         this.schema = schema;
         this.dispatcher = dispatcher;
         this.clock = clock;
@@ -39,11 +33,11 @@ public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSou
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, ScyllaPartition partition, ScyllaOffsetContext offsetContext) throws InterruptedException {
         Driver3Session session = new ScyllaSessionBuilder(configuration).build();
         Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
         ScyllaWorkerTransport workerTransport = new ScyllaWorkerTransport(context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
-        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock, configuration.getPreimagesEnabled());
+        ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock, configuration);
         WorkerConfiguration workerConfiguration = WorkerConfiguration.builder()
                 .withTransport(workerTransport)
                 .withCQL(cql)

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaTaskContext.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaTaskContext.java
@@ -2,9 +2,10 @@ package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.model.StreamId;
 import com.scylladb.cdc.model.TaskId;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
@@ -19,7 +20,7 @@ public class ScyllaTaskContext extends CdcSourceTaskContext {
     private final List<Pair<TaskId, SortedSet<StreamId>>> tasks;
 
     public ScyllaTaskContext(Configuration config, List<Pair<TaskId, SortedSet<StreamId>>> tasks) {
-        super(Module.contextName(), config.getString(ScyllaConnectorConfig.LOGICAL_NAME), Collections::emptySet);
+        super(Module.contextName(), config.getString(CommonConnectorConfig.TOPIC_PREFIX), new ScyllaConnectorConfig(config).getCustomMetricTags(), Collections::emptySet);
         this.tasks = tasks;
     }
 

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaWorkerTransport.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaWorkerTransport.java
@@ -16,14 +16,17 @@ import java.util.Set;
 public class ScyllaWorkerTransport implements WorkerTransport {
 
     private final ChangeEventSource.ChangeEventSourceContext context;
+    //private final ScyllaPartition partition;
     private final ScyllaOffsetContext offsetContext;
-    private final EventDispatcher<CollectionId> dispatcher;
+    private final EventDispatcher<ScyllaPartition, CollectionId> dispatcher;
     private final Map<TaskId, Threads.Timer> heartbeatTimers;
     private final long heartbeatIntervalMs;
 
-    public ScyllaWorkerTransport(ChangeEventSource.ChangeEventSourceContext context, ScyllaOffsetContext offsetContext, EventDispatcher<CollectionId> dispatcher,
-                                 long heartbeatIntervalMs) {
+    public ScyllaWorkerTransport(ChangeEventSource.ChangeEventSourceContext context,
+                                 ScyllaOffsetContext offsetContext,
+                                 EventDispatcher<ScyllaPartition, CollectionId> dispatcher, long heartbeatIntervalMs) {
         this.context = context;
+        //this.partition = partition;
         this.offsetContext = offsetContext;
         this.dispatcher = dispatcher;
         this.heartbeatTimers = new HashMap<>();
@@ -56,7 +59,7 @@ public class ScyllaWorkerTransport implements WorkerTransport {
         taskStateOffsetContext.dataChangeEvent(newState);
         try {
             if (heartbeatTimer.expired()) {
-                dispatcher.alwaysDispatchHeartbeatEvent(taskStateOffsetContext);
+                dispatcher.alwaysDispatchHeartbeatEvent(new ScyllaPartition(offsetContext, taskStateOffsetContext.sourceInfo), taskStateOffsetContext);
                 // Reset the timer.
                 heartbeatTimers.put(task, buildHeartbeatTimer());
             }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/TaskStateOffsetContext.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/TaskStateOffsetContext.java
@@ -2,9 +2,10 @@ package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.model.TaskId;
 import com.scylladb.cdc.model.worker.TaskState;
+import io.debezium.connector.SnapshotRecord;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
-import io.debezium.schema.DataCollectionId;
+import io.debezium.spi.schema.DataCollectionId;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
@@ -13,16 +14,11 @@ import java.util.Map;
 
 public class TaskStateOffsetContext implements OffsetContext {
     private final ScyllaOffsetContext scyllaOffsetContext;
-    private final SourceInfo sourceInfo;
+    final SourceInfo sourceInfo;
 
     public TaskStateOffsetContext(ScyllaOffsetContext scyllaOffsetContext, SourceInfo sourceInfo) {
         this.scyllaOffsetContext = scyllaOffsetContext;
         this.sourceInfo = sourceInfo;
-    }
-
-    @Override
-    public Map<String, ?> getPartition() {
-        return sourceInfo.partition();
     }
 
     @Override
@@ -54,7 +50,7 @@ public class TaskStateOffsetContext implements OffsetContext {
     }
 
     @Override
-    public void markLastSnapshotRecord() {
+    public void markSnapshotRecord(SnapshotRecord snapshotRecord) {
 
     }
 


### PR DESCRIPTION
Upgrades to Debezium 2.6.2.Final.
Tested with minimal CDC enabled table. 
Offsets persist between pauses and restarts.

SMTs were not tested