### PR TITLE
Basic setup for integration testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>
@@ -207,6 +225,13 @@
                 <artifactId>snappy-java</artifactId>
                 <version>1.1.10.5</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.13.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -314,6 +339,11 @@
                 </exclusion>
 
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,30 @@
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <version>${debezium.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.21.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>scylladb</artifactId>
+            <version>1.21.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.21.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- FIXME: Delete this dependency:-->
         <dependency>

--- a/src/test/java/com/scylladb/cdc/debezium/connector/StartConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/StartConnectorIT.java
@@ -1,0 +1,109 @@
+package com.scylladb.cdc.debezium.connector;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import io.debezium.testing.testcontainers.ConnectorConfiguration;
+import io.debezium.testing.testcontainers.DebeziumContainer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.scylladb.ScyllaDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public class StartConnectorIT {
+
+  private static Network network = Network.newNetwork();
+
+  private static KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.12"))
+      .withNetwork(network);
+
+  public static ScyllaDBContainer scyllaDBContainer = new ScyllaDBContainer("scylladb/scylla:6.2")
+      .withNetwork(network)
+      .withNetworkAliases("scylla")
+      .withExposedPorts(9042, 19042);
+
+  public static DebeziumContainer debeziumContainer =
+      new DebeziumContainer("quay.io/debezium/connect:2.6.2.Final")
+          // Requires connector to be built first
+          .withFileSystemBind("target/components/packages/", "/kafka/connect/plugins/")
+          .withNetwork(network)
+          .withKafka(kafkaContainer)
+          .dependsOn(kafkaContainer);
+
+  @BeforeClass
+  public static void startContainers() {
+    Startables.deepStart(Stream.of(
+            kafkaContainer, scyllaDBContainer, debeziumContainer))
+        .join();
+  }
+
+  @Test
+  public void canRegisterScyllaConnector() {
+    try (Cluster cluster =
+             Cluster
+                 .builder()
+                 .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
+                 .withPort(scyllaDBContainer.getMappedPort(9042))
+                 .build();
+         KafkaConsumer<String, String> consumer =
+             getConsumer(kafkaContainer)) {
+      Session session = cluster.connect();
+      session.execute("CREATE KEYSPACE IF NOT EXISTS connectortest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
+      // Create a table with cdc enabled
+      session.execute("CREATE TABLE IF NOT EXISTS connectortest.test_table (id int PRIMARY KEY, name text) WITH cdc = {'enabled':true}");
+      session.execute("INSERT INTO connectortest.test_table (id, name) VALUES (1, 'test_text');");
+      session.close();
+      ConnectorConfiguration connector =
+          ConnectorConfiguration
+              .create()
+              .with("connector.class", "com.scylladb.cdc.debezium.connector.ScyllaConnector")
+              .with("scylla.cluster.ip.addresses", "scylla:9042")
+              .with("topic.prefix", "namespace")
+              .with("scylla.table.names", "connectortest.test_table")
+              .with("tasks.max", "1")
+              .with("name", "ScyllaTestConnector");
+      debeziumContainer.registerConnector("ScyllaTestConnector", connector);
+      consumer.subscribe(List.of("namespace.connectortest.test_table"));
+      // Wait for at most 65 seconds for the connector to start and generate the message
+      // corresponding to the inserted row
+      long startTime = System.currentTimeMillis();
+      boolean messageConsumed = false;
+      while (System.currentTimeMillis() - startTime < 65 * 1000) {
+        var records = consumer.poll(java.time.Duration.ofSeconds(5));
+        if (!records.isEmpty()) {
+          messageConsumed = true;
+          records.forEach(record -> {
+            assert record.value().contains("{\"id\":1,\"name\":{\"value\":\"test_text\"}}");
+          });
+          break;
+        }
+      }
+      consumer.unsubscribe();
+      assert messageConsumed;
+    }
+  }
+
+  private KafkaConsumer<String, String> getConsumer(
+      KafkaContainer kafkaContainer) {
+    return new KafkaConsumer<>(
+        Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            kafkaContainer.getBootstrapServers(),
+            ConsumerConfig.GROUP_ID_CONFIG,
+            "tc-" + UUID.randomUUID(),
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+            "earliest"),
+        new StringDeserializer(),
+        new StringDeserializer());
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/StartConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/StartConnectorIT.java
@@ -7,8 +7,8 @@ import io.debezium.testing.testcontainers.DebeziumContainer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
@@ -40,7 +40,7 @@ public class StartConnectorIT {
           .withKafka(kafkaContainer)
           .dependsOn(kafkaContainer);
 
-  @BeforeClass
+  @BeforeAll
   public static void startContainers() {
     Startables.deepStart(Stream.of(
             kafkaContainer, scyllaDBContainer, debeziumContainer))


### PR DESCRIPTION
Adds dependencies for Testcontainers along with simple test utilizing containers for ScyllaDB, Kafka and Kafka Connect with Debezium. Picked versions that match current Debezium version used (2.6.2.Final).
The test simply checks whether connector can be registered successfully and if it produces a single message.