### PR TITLE
release: make dry-run work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,14 +78,15 @@ jobs:
           SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         run: |
-          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
-            MAVEN_OPTS="${MAVEN_OPTS} -Drelease.autopublish=false"
+          DRY_RUN_OPTS = ""
+          if [[ "${{ inputs.dry-run }}" != "true" ]]; then
+            DRY_RUN_OPTS="-Drelease.autopublish=true"
           fi
           if [[ "${{ inputs.skip-tests }}" == "true" ]]; then
             MAVEN_OPTS="${MAVEN_OPTS} -DskipTests=true -DskipITs=true"
           fi
           export MAVEN_OPTS
-          $MVNCMD release:perform -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} > >(tee /tmp/logs-stdout.log) 2> >(tee /tmp/logs-stderr.log)
+          $MVNCMD release:perform $DRY_RUN_OPTS -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} > >(tee /tmp/logs-stdout.log) 2> >(tee /tmp/logs-stderr.log)
 
       - name: Upload stdout.log
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
                     <releaseProfiles>release</releaseProfiles>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                    <arguments>-Dgpg.passphrase=${gpg.passphrase} -Drelease.autopublish=${release.autopublish}</arguments>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -169,7 +169,7 @@
     </build>
 
     <properties>
-        <release.autopublish>true</release.autopublish>
+        <release.autopublish>false</release.autopublish>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
         <debezium.version>2.6.2.Final</debezium.version>


### PR DESCRIPTION
Currently dry-run publish package.
This commit will make central-publishing-maven-plugin not to publish by default and publish only when `release.autopublish` is true