### PR TITLE
dependancy: update kafka version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <debezium.version>2.6.2.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
-        <kafka.version>3.3.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
         <scylla.driver.version>3.11.5.7</scylla.driver.version>
         <scylla.cdc.java.version>1.3.6</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>


### PR DESCRIPTION
There is reported vulnerability in `3.3.1` that is addressed in `3.7.1`.