### PR TITLE
Adjust name for manifest.json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
                             <goal>kafka-connect</goal>
                         </goals>
                         <configuration>
-                            <name>kafka-connect-scylla-cdc</name>
+                            <name>scylla-cdc-source-connector</name>
                             <title>Scylla CDC Source Connector</title>
                             <documentationUrl>https://github.com/scylladb/scylla-cdc-source-connector</documentationUrl>
                             <description>


### PR DESCRIPTION
Seems it was "kafka-connect-scylla-cdc" instead of "scylla-cdc-source-connector". This also changes the name of produced zip package.