### PR TITLE
Set bcpkix-jdk18on version to 1.79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,11 @@
                 <artifactId>kafka-avro-serializer</artifactId>
                 <version>8.0.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.79</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This gets rid of CVE-2025-8916 from security scanner reports.