### PR TITLE
Fix CVE-2025-58057 by updating netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,12 +266,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.119.Final</version>
+                <version>4.1.125.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.119.Final</version>
+                <version>4.1.125.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
CVE-2025-58057 is fixed on 4.1.125.Final
So, let's update netty