### PR TITLE
chore(deps): upgrade testcontainers to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,24 +343,30 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.3</version>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>scylladb</artifactId>
-            <version>1.21.3</version>
+            <artifactId>testcontainers-scylladb</artifactId>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>1.21.3</version>
+            <artifactId>testcontainers-kafka</artifactId>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.17.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
1. Update testcontainer monorepo to v2
2. Adds `commons-io` which is required for testcontaine