### PR TITLE
Update cicd to run on java 17

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -43,15 +43,18 @@ jobs:
             kafka_version: "4.0.0"
             kafka_connect_mode: "standalone"
             scylla_version: "6.2"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Set up JDK 11
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: temurin
+          java-version: 17
           cache: maven
+
       - name: Increase fs.aio-max-nr limit
         run: |
           echo "Current fs.aio-max-nr value:"
@@ -59,5 +62,6 @@ jobs:
           sudo sysctl -w fs.aio-max-nr=1048576
           echo "New fs.aio-max-nr value:"
           cat /proc/sys/fs/aio-max-nr
+
       - name: Maven verify
         run: mvn -B verify -Dit.kafka.provider=${{ matrix.kafka_provider }} -Dit.kafka.version=${{ matrix.kafka_version }} -Dit.kafka.connect.mode=${{ matrix.kafka_connect_mode }} -Dit.scylla.version=${{ matrix.scylla_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: 17
+          distribution: temurin
           server-id: central
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           server-username: SONATYPE_TOKEN_USERNAME


### PR DESCRIPTION
To move forward with maven plugins we need to have newer java. Let's update runtime java to 17.