### PR TITLE
tests: rename it.kafka.version to it.provider.image.version

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -12,35 +12,35 @@ jobs:
       matrix:
         include:
           - kafka_provider: "confluent"
-            kafka_version: "8.0.0"
+            provider_image_version: "8.0.0"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "confluent"
-            kafka_version: "7.9.2"
+            provider_image_version: "7.9.2"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "confluent"
-            kafka_version: "7.8.3"
+            provider_image_version: "7.8.3"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "confluent"
-            kafka_version: "7.7.4"
+            provider_image_version: "7.7.4"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "confluent"
-            kafka_version: "7.6.6"
+            provider_image_version: "7.6.6"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "confluent"
-            kafka_version: "8.0.0"
+            provider_image_version: "8.0.0"
             kafka_connect_mode: "standalone"
             scylla_version: "6.2"
           - kafka_provider: "apache"
-            kafka_version: "4.0.0"
+            provider_image_version: "4.0.0"
             kafka_connect_mode: "distributed"
             scylla_version: "6.2"
           - kafka_provider: "apache"
-            kafka_version: "4.0.0"
+            provider_image_version: "4.0.0"
             kafka_connect_mode: "standalone"
             scylla_version: "6.2"
 
@@ -64,4 +64,4 @@ jobs:
           cat /proc/sys/fs/aio-max-nr
 
       - name: Maven verify
-        run: mvn -B verify -Dit.kafka.provider=${{ matrix.kafka_provider }} -Dit.kafka.version=${{ matrix.kafka_version }} -Dit.kafka.connect.mode=${{ matrix.kafka_connect_mode }} -Dit.scylla.version=${{ matrix.scylla_version }}
+        run: mvn -B verify -Dit.kafka.provider=${{ matrix.kafka_provider }} -Dit.provider.image.version=${{ matrix.provider_image_version }} -Dit.kafka.connect.mode=${{ matrix.kafka_connect_mode }} -Dit.scylla.version=${{ matrix.scylla_version }}


### PR DESCRIPTION
Current name is confusing by two reasons:
1. There is already present `kafka.version` mvn property
2. For confluent provider it is not a `kafka` version, it is version of confluent platform, which have completely different versioning, as of now top confluent platform version is 8.x, while kafka is `4.x`.