### PR TITLE
Depricate old java versions

### DIFF
--- a/cp-quickstart/README.md
+++ b/cp-quickstart/README.md
@@ -5,7 +5,7 @@ This guide will walk you through setting up and using the Scylla CDC Source Conn
 ## Prerequisites
 
 - Clone this repository
-- Have Java 11 or later and Maven installed
+- Have Java 17 or later and Maven installed
 - Make sure you fulfill the requirements listed at https://docs.confluent.io/platform/current/get-started/platform-quickstart.html
 
 ## Setup Process

--- a/pom.xml
+++ b/pom.xml
@@ -181,9 +181,9 @@
     <properties>
         <release.autopublish>false</release.autopublish>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <debezium.version>2.7.4.Final</debezium.version>
-        <!-- Docs claim java 8 supported, but support is deprecated -->
+        <!-- Connector requires Java 17 or later -->
         <kafka.version>3.9.1</kafka.version>
         <scylla.driver.version>3.11.5.9</scylla.driver.version>
         <scylla.cdc.java.version>1.3.7</scylla.cdc.java.version>


### PR DESCRIPTION
Start building for java 17, dropping support for java 8 and java 11.

To be released as part of next minor.