### PR TITLE
chore(deps): update `maven-release-plugin` version to `3.2.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
Update `maven-release-plugin` version to `3.2.0` ensuring compatibility with JDK and `maven-scm-provider-gitexe` of version `2.2.1`.