### PR TITLE
Replacing `org.lz4` with `at.yawk.lz4` to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <debezium.version>2.7.4.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
-        <kafka.version>8.1.0-ce</kafka.version>
+        <kafka.version>8.1.1-ce</kafka.version>
         <scylla.driver.version>3.11.5.11</scylla.driver.version>
         <scylla.cdc.java.version>1.3.7</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
@@ -328,11 +328,28 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-transforms</artifactId>
             <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>


### PR DESCRIPTION
- Updates Kafka version from `8.1.0-ce` to `8.1.1-ce`
- Excludes vulnerable `org.lz4:lz4-java` from Kafka Connect dependencies
- Adds `at.yawk.lz4:lz4-java:1.10.1` as a replacement to address vulnerabilities

Fixes: https://github.com/scylladb/scylla-cdc-source-connector/issues/193