### PR TITLE
Add more tests

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -6,9 +6,11 @@ on:
       - master
 
 jobs:
-  build:
+  run-tests:
+    name: "Run integration tests"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - kafka_provider: "confluent"

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.1</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <testRelease>${maven.compiler.testRelease}</testRelease>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.spotify.fmt</groupId>
@@ -39,6 +43,26 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[17,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -182,6 +206,7 @@
         <release.autopublish>false</release.autopublish>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <debezium.version>2.7.4.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>8.1.1-ccs</kafka.version>
@@ -445,6 +470,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkAvroConnectorIT.java
@@ -1,0 +1,92 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildAvroConnector;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaCompositePkAvroConnectorIT
+    extends ScyllaCompositePkBase<GenericRecord, GenericRecord> {
+
+  @BeforeAll
+  static void checkKafkaProvider() {
+    Assumptions.assumeTrue(
+        KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
+    Assumptions.assumeTrue(
+        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
+        "Avro tests require distributed mode, otherwise Avro converter is not available");
+  }
+
+  @Override
+  KafkaConsumer<GenericRecord, GenericRecord> buildConsumer(
+      String connectorName, String tableName) {
+    return buildAvroConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(
+          testInfo,
+          "c",
+          "null",
+          """
+                {
+                  "pk1": 1,
+                  "pk2": "%s",
+                  "pk3": "%s",
+                  "pk4": 10,
+                  "value_text": {"value": "first"},
+                  "value_int": {"value": 100}
+                }
+                """
+              .formatted(PK2_VALUE, PK3_VALUE))
+    };
+  }
+
+  @Override
+  String[] expectedUpdate(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+                {
+                  "pk1": 1,
+                  "pk2": "%s",
+                  "pk3": "%s",
+                  "pk4": 10,
+                  "value_text": {"value": "second"},
+                  "value_int": {"value": 200}
+                }
+                """
+              .formatted(PK2_VALUE, PK3_VALUE))
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "d",
+          """
+                {
+                  "pk1": 1,
+                  "pk2": "%s",
+                  "pk3": "%s",
+                  "pk4": 10
+                }
+                """
+              .formatted(PK2_VALUE, PK3_VALUE),
+          "null"),
+      null
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkBase.java
@@ -1,0 +1,98 @@
+package com.scylladb.cdc.debezium.connector;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public abstract class ScyllaCompositePkBase<K, V> extends ScyllaTypesIT<K, V> {
+  protected static final String PK2_VALUE = "alpha";
+  protected static final String PK3_VALUE = "11111111-1111-1111-1111-111111111111";
+
+  abstract String[] expectedInsert(TestInfo testInfo);
+
+  abstract String[] expectedUpdate(TestInfo testInfo);
+
+  abstract String[] expectedDelete(TestInfo testInfo);
+
+  @BeforeAll
+  static void setupKeyspace(TestInfo testInfo) {
+    session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS "
+            + keyspaceName(testInfo)
+            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
+  }
+
+  @Override
+  protected String createTableCql(String tableName) {
+    return "("
+        + "pk1 int,"
+        + "pk2 text,"
+        + "pk3 uuid,"
+        + "pk4 int,"
+        + "value_text text,"
+        + "value_int int,"
+        + "PRIMARY KEY ((pk1, pk2), pk3, pk4)"
+        + ")";
+  }
+
+  @Test
+  void testInsertWithMultiColumnPk(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
+            + "1, '"
+            + PK2_VALUE
+            + "', "
+            + PK3_VALUE
+            + ", 10, 'first', 100);");
+    waitAndAssert(getConsumer(), expectedInsert(testInfo));
+  }
+
+  @Test
+  void testUpdateWithMultiColumnPk(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
+            + "1, '"
+            + PK2_VALUE
+            + "', "
+            + PK3_VALUE
+            + ", 10, 'first', 100);");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET value_text = 'second', value_int = 200 WHERE pk1 = 1 AND pk2 = '"
+            + PK2_VALUE
+            + "' AND pk3 = "
+            + PK3_VALUE
+            + " AND pk4 = 10;");
+    waitAndAssert(getConsumer(), expectedUpdate(testInfo));
+  }
+
+  @Test
+  void testDeleteWithMultiColumnPk(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
+            + "1, '"
+            + PK2_VALUE
+            + "', "
+            + PK3_VALUE
+            + ", 10, 'first', 100);");
+    session.execute(
+        "DELETE FROM "
+            + keyspaceTableName(testInfo)
+            + " WHERE pk1 = 1 AND pk2 = '"
+            + PK2_VALUE
+            + "' AND pk3 = "
+            + PK3_VALUE
+            + " AND pk4 = 10;");
+    waitAndAssert(getConsumer(), expectedDelete(testInfo));
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkNewRecordStateConnectorIT.java
@@ -1,0 +1,67 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildScyllaExtractNewRecordStateConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaCompositePkNewRecordStateConnectorIT
+    extends ScyllaCompositePkBase<String, String> {
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildScyllaExtractNewRecordStateConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "pk1": 1,
+          "pk2": "%s",
+          "pk3": "%s",
+          "pk4": 10,
+          "value_text": "first",
+          "value_int": 100
+        }
+        """
+          .formatted(PK2_VALUE, PK3_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedUpdate(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "pk1": 1,
+          "pk2": "%s",
+          "pk3": "%s",
+          "pk4": 10,
+          "value_text": "second",
+          "value_int": 200
+        }
+        """
+          .formatted(PK2_VALUE, PK3_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "pk1": 1,
+          "pk2": "%s",
+          "pk3": "%s",
+          "pk4": 10
+        }
+        """
+          .formatted(PK2_VALUE, PK3_VALUE)
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkPlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkPlainConnectorIT.java
@@ -1,0 +1,78 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaCompositePkPlainConnectorIT extends ScyllaCompositePkBase<String, String> {
+
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildPlainConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(
+          testInfo,
+          "c",
+          "null",
+          """
+            {
+              "pk1": 1,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": 10,
+              "value_text": {"value": "first"},
+              "value_int": {"value": 100}
+            }
+            """
+              .formatted(PK2_VALUE, PK3_VALUE))
+    };
+  }
+
+  @Override
+  String[] expectedUpdate(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "pk1": 1,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": 10,
+              "value_text": {"value": "second"},
+              "value_int": {"value": 200}
+            }
+            """
+              .formatted(PK2_VALUE, PK3_VALUE))
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "d",
+          """
+            {
+              "pk1": 1,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": 10
+            }
+            """
+              .formatted(PK2_VALUE, PK3_VALUE),
+          "null"),
+      null
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesIT.java
@@ -1,327 +1,212 @@
 package com.scylladb.cdc.debezium.connector;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
-import java.net.UnknownHostException;
+import com.google.common.flogger.FluentLogger;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
-public class ScyllaTypesIT extends AbstractContainerBaseIT {
+/**
+ * Base class for Scylla types integration tests. Provides common infrastructure for test setup,
+ * teardown, and Kafka consumer management.
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
+public abstract class ScyllaTypesIT<K, V> extends AbstractContainerBaseIT {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+  private static final Object DDL_LOCK = new Object();
 
-  private static final String SCYLLA_ALL_TYPES_CONNECTOR = "ScyllaAllTypesConnector";
+  static Session session;
+  static int SessionCount;
+  private static final Object SESSION_LOCK = new Object();
+
+  private KafkaConsumer<K, V> consumer;
+
+  /** Returns the CQL CREATE TABLE statement (without "IF NOT EXISTS" and CDC options). */
+  protected abstract String createTableCql(String tableName);
+
+  /** Builds and returns a Kafka consumer for the given connector and table. */
+  abstract KafkaConsumer<K, V> buildConsumer(String connectorName, String tableName);
+
+  /** Waits for and asserts expected Kafka messages. */
+  void waitAndAssert(KafkaConsumer<K, V> consumer, String[] expected) {
+    List<ConsumerRecord<K, V>> actual = new ArrayList<>();
+    KafkaConnectUtils.waitForConsumerAssignment(consumer);
+
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < KafkaConnectUtils.CONSUMER_TIMEOUT) {
+      consumer.poll(Duration.ofSeconds(5)).forEach(actual::add);
+      if (expected.length <= actual.size()) {
+        break;
+      }
+    }
+
+    List<String> errors = new ArrayList<>();
+    assertEquals(expected.length, actual.size());
+
+    for (int i = 0; i < expected.length; i++) {
+      String exp = expected[i];
+
+      V value = actual.get(i).value();
+
+      String got;
+      if (value instanceof String) {
+        got = (String) value;
+      } else if (value == null) {
+        got = null;
+      } else {
+        got = value.toString();
+      }
+
+      if (exp == null || got == null) {
+        if (exp != got) { // reference check is fine here: null vs non-null
+          errors.add("Record[" + i + "] mismatch:\nexpected: " + exp + "\nactual:   " + got);
+        }
+        continue;
+      }
+
+      try {
+        JSONAssert.assertEquals(exp, got, JSONCompareMode.LENIENT);
+      } catch (AssertionError e) {
+        errors.add(
+            "Record["
+                + i
+                + "] mismatch:\nexpected: "
+                + exp
+                + "\nactual:   "
+                + got
+                + "\n"
+                + e.getMessage());
+      } catch (Exception e) {
+        errors.add(
+            "Record["
+                + i
+                + "] JSON compare failed:\nexpected: "
+                + exp
+                + "\nactual:   "
+                + got
+                + "\n"
+                + e);
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      Assertions.fail(String.join("\n\n", errors));
+    }
+  }
 
   @BeforeAll
-  public static void setupTable() {
-    // Does not include counter columns, as they are not allowed to be mixed with non-counter
-    // columns in the same table.
-    try (Cluster cluster =
-        Cluster.builder()
-            .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
-            .withPort(scyllaDBContainer.getMappedPort(9042))
-            .build()) {
-      Session session = cluster.connect();
-      session.execute(
-          "CREATE KEYSPACE IF NOT EXISTS primitive_types_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
-      session.execute(
-          "CREATE TABLE IF NOT EXISTS primitive_types_ks.tab ("
-              + "id int PRIMARY KEY,"
-              + "ascii_col ascii,"
-              + "bigint_col bigint,"
-              + "blob_col blob,"
-              + "boolean_col boolean,"
-              + "date_col date,"
-              + "decimal_col decimal,"
-              + "double_col double,"
-              + "duration_col duration,"
-              + "float_col float,"
-              + "inet_col inet,"
-              + "int_col int,"
-              + "smallint_col smallint,"
-              + "text_col text,"
-              + "time_col time,"
-              + "timestamp_col timestamp,"
-              + "timeuuid_col timeuuid,"
-              + "tinyint_col tinyint,"
-              + "uuid_col uuid,"
-              + "varchar_col varchar,"
-              + "varint_col varint"
-              + ") WITH cdc = {'enabled':true}");
-      session.execute(
-          "INSERT INTO primitive_types_ks.tab (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col) VALUES ("
-              + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'some text', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999)"
-              + ";");
-      session.close();
+  public static synchronized void setupSuite() {
+    synchronized (SESSION_LOCK) {
+      if (SessionCount == 0 && session == null) {
+        session =
+            Cluster.builder()
+                .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
+                .withPort(scyllaDBContainer.getMappedPort(9042))
+                .build()
+                .connect();
+      }
+      SessionCount++;
     }
+  }
+
+  @AfterAll
+  public static void cleanupSuite() {
+    synchronized (SESSION_LOCK) {
+      SessionCount--;
+      if (SessionCount == 0 && session != null) {
+        session.close();
+        session = null;
+      }
+    }
+  }
+
+  @BeforeEach
+  void setupTest(TestInfo testInfo) {
+    synchronized (DDL_LOCK) {
+      session.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + keyspaceTableName(testInfo)
+              + " "
+              + createTableCql(keyspaceTableName(testInfo))
+              + " WITH cdc = {'enabled':true}");
+    }
+
+    consumer = buildConsumer(connectorName(testInfo), keyspaceTableName(testInfo));
   }
 
   @AfterEach
-  public void cleanUp() {
+  public void cleanUp(TestInfo testInfo) {
+    if (consumer != null) {
+      consumer.close();
+      consumer = null;
+    }
     try {
-      KafkaConnectUtils.removeAllConnectors();
+      KafkaConnectUtils.removeConnector(connectorName(testInfo));
     } catch (Exception e) {
-      throw new RuntimeException("Failed to remove the connectors.", e);
+      throw new RuntimeException("Failed to remove connector: " + connectorName(testInfo), e);
+    }
+    synchronized (DDL_LOCK) {
+      if (session != null && !session.isClosed()) {
+        session.execute("DROP TABLE IF EXISTS " + keyspaceTableName(testInfo));
+      } else {
+        logger.atWarning().log(
+            "Skipping table cleanup because session is closed: %s", keyspaceTableName(testInfo));
+      }
     }
   }
 
-  @Test
-  public void canReplicateAllPrimitiveTypes() throws UnknownHostException {
-    try (KafkaConsumer<String, String> consumer = KafkaUtils.createStringConsumer()) {
-      Properties connectorConfiguration = KafkaConnectUtils.createCommonConnectorProperties();
-      connectorConfiguration.put("topic.prefix", "canReplicateAllPrimitiveTypes");
-      connectorConfiguration.put("scylla.table.names", "primitive_types_ks.tab");
-      connectorConfiguration.put("name", SCYLLA_ALL_TYPES_CONNECTOR);
-      int returnCode = -1;
-      try {
-        returnCode =
-            KafkaConnectUtils.registerConnector(connectorConfiguration, SCYLLA_ALL_TYPES_CONNECTOR);
-        // If we get a 500 error, check if the connector is actually registered (see issue #195)
-        if (returnCode == 500) {
-          String status = KafkaConnectUtils.getConnectorStatus(SCYLLA_ALL_TYPES_CONNECTOR);
-          if (status == null) {
-            Assertions.fail(
-                "Received 500 error on connector registration and connector is not registered.");
+  protected void truncateTables(TestInfo testInfo) {
+    session.execute("TRUNCATE TABLE " + keyspaceTableName(testInfo));
+    session.execute("TRUNCATE TABLE " + cdcLogTableName(testInfo));
+  }
+
+  private String cdcLogTableName(TestInfo testInfo) {
+    return keyspaceName(testInfo) + "." + tableName(testInfo) + "_scylla_cdc_log";
+  }
+
+  protected KafkaConsumer<K, V> getConsumer() {
+    return consumer;
+  }
+
+  public static String expectedRecord(
+      TestInfo testInfo, String op, String beforeJson, String afterJson) {
+    return """
+        {
+          "before": %s,
+          "after": %s,
+          "op": "%s",
+          "source": {
+            "connector": "scylla",
+            "name": "%s",
+            "snapshot": "false",
+            "db": "%s",
+            "keyspace_name": "%s",
+            "table_name": "%s"
           }
-        } else if (returnCode / 100 != 2) {
-          Assertions.fail(
-              "Received non-success response code on connector registration: " + returnCode);
         }
-      } catch (Exception e) {
-        Assertions.fail("Failed to register connector.", e);
-      }
-      consumer.subscribe(List.of("canReplicateAllPrimitiveTypes.primitive_types_ks.tab"));
-      long startTime = System.currentTimeMillis();
-      boolean messageConsumed = false;
-      while (System.currentTimeMillis() - startTime < 65 * 1000) {
-        var records = consumer.poll(java.time.Duration.ofSeconds(5));
-        if (!records.isEmpty()) {
-          messageConsumed = true;
-          records.forEach(
-              record -> {
-                String value = record.value();
-                assert value.contains("\"id\":1");
-                assert value.contains("\"ascii_col\":{" + "\"value\":\"ascii\"}");
-                assert value.contains("\"bigint_col\":{" + "\"value\":1234567890123}");
-                assert value.contains("\"blob_col\":{" + "\"value\":\"yv66vg==\"}");
-                assert value.contains("\"boolean_col\":{" + "\"value\":true}");
-                // This is number of days since unix epoch that should correspond to '2024-06-10'
-                assert value.contains("\"date_col\":{" + "\"value\":19884}");
-                assert value.contains("\"decimal_col\":{" + "\"value\":\"12345.67\"}");
-                assert value.contains("\"double_col\":{" + "\"value\":3.14159}");
-                assert value.contains("\"duration_col\":{" + "\"value\":\"1d12h30m\"");
-                assert value.contains("\"float_col\":{" + "\"value\":2.71828}");
-                assert value.contains("\"inet_col\":{" + "\"value\":\"127.0.0.1\"}");
-                assert value.contains("\"int_col\":{" + "\"value\":42}");
-                assert value.contains("\"smallint_col\":{" + "\"value\":7}");
-                assert value.contains("\"text_col\":{" + "\"value\":\"some text\"}");
-                // Shows up as 45296789000000.
-                // 45296789 part of the value is the number of milliseconds since midnight that
-                // corresponds to '12:34:56.789'
-                assert value.contains("\"time_col\":{" + "\"value\":45296789000000}");
-                // 1718022896789 is unix timestamp in milliseconds for '2024-06-10T12:34:56.789Z'
-                assert value.contains("\"timestamp_col\":{" + "\"value\":1718022896789}");
-                assert value.contains(
-                    "\"timeuuid_col\":{" + "\"value\":\"81d4a030-4632-11f0-9484-409dd8f36eba\"");
-                assert value.contains("\"tinyint_col\":{" + "\"value\":5}");
-                assert value.contains(
-                    "\"uuid_col\":{" + "\"value\":\"453662fa-db4b-4938-9033-d8523c0a371c\"}");
-                assert value.contains("\"varchar_col\":{" + "\"value\":\"varchar text\"}");
-                assert value.contains("\"varint_col\":{" + "\"value\":\"999999999\"}");
-              });
-          break;
-        }
-      }
-      consumer.unsubscribe();
-      Assertions.assertTrue(
-          messageConsumed,
-          "No message consumed from the topic. Topic may be empty or connector may have crashed.");
-    }
-  }
-
-  @Test
-  public void canExtractNewRecordState() {
-    try (KafkaConsumer<String, String> consumer = KafkaUtils.createStringConsumer()) {
-      Properties connectorConfiguration = KafkaConnectUtils.createCommonConnectorProperties();
-      connectorConfiguration.put("topic.prefix", "canExtractNewRecordState");
-      connectorConfiguration.put("scylla.table.names", "primitive_types_ks.tab");
-      connectorConfiguration.put("name", "canExtractNewRecordState");
-      connectorConfiguration.put("transforms", "extractNewRecordState");
-      connectorConfiguration.put(
-          "transforms.extractNewRecordState.type",
-          "com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState");
-      try {
-        KafkaConnectUtils.registerConnector(connectorConfiguration, "canExtractNewRecordState");
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to register connector.", e);
-      }
-      consumer.subscribe(List.of("canExtractNewRecordState.primitive_types_ks.tab"));
-      long startTime = System.currentTimeMillis();
-      boolean messageConsumed = false;
-      while (System.currentTimeMillis() - startTime < 65 * 1000) {
-        var records = consumer.poll(java.time.Duration.ofSeconds(5));
-        if (!records.isEmpty()) {
-          messageConsumed = true;
-          records.forEach(
-              record -> {
-                String value = record.value();
-                assert value.contains("{\"ascii_col\":\"ascii\"");
-                assert value.contains("\"bigint_col\":1234567890123");
-                assert value.contains("\"blob_col\":\"yv66vg==\"");
-                assert value.contains("\"boolean_col\":true");
-                assert value.contains("\"date_col\":19884");
-                assert value.contains("\"decimal_col\":\"12345.67\"");
-                assert value.contains("\"double_col\":3.14159");
-                assert value.contains("\"duration_col\":\"1d12h30m\"");
-                assert value.contains("\"float_col\":2.71828");
-                assert value.contains("\"id\":1");
-                assert value.contains("\"inet_col\":\"127.0.0.1\"");
-                assert value.contains("\"int_col\":42");
-                assert value.contains("\"smallint_col\":7");
-                assert value.contains("\"text_col\":\"some text\"");
-                assert value.contains("\"time_col\":45296789000000");
-                assert value.contains("\"timestamp_col\":1718022896789");
-                assert value.contains("\"timeuuid_col\":\"81d4a030-4632-11f0-9484-409dd8f36eba\"");
-                assert value.contains("\"tinyint_col\":5");
-                assert value.contains("\"uuid_col\":\"453662fa-db4b-4938-9033-d8523c0a371c\"");
-                assert value.contains("\"varchar_col\":\"varchar text\"");
-                assert value.contains("\"varint_col\":\"999999999\"}");
-              });
-          break;
-        }
-      }
-      consumer.unsubscribe();
-      Assertions.assertTrue(
-          messageConsumed,
-          "No message consumed from the topic. Topic may be empty or connector may have crashed.");
-    }
-  }
-
-  @Test
-  @EnabledIf("isConfluentKafkaProvider")
-  public void canReplicateAllPrimitiveTypesWithAvro() {
-    Assumptions.assumeTrue(
-        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
-        "AvroConverter is not available in cp-kafka image.");
-    try (KafkaConsumer<GenericRecord, GenericRecord> consumer = KafkaUtils.createAvroConsumer()) {
-      Properties connectorConfiguration = KafkaConnectUtils.createAvroConnectorProperties();
-      connectorConfiguration.put("topic.prefix", "canReplicateAllPrimitiveTypesWithAvro");
-      connectorConfiguration.put("scylla.table.names", "primitive_types_ks.tab");
-      connectorConfiguration.put("name", "ScyllaAllTypesAvroConnector");
-      int returnCode = -1;
-      try {
-        returnCode =
-            KafkaConnectUtils.registerConnector(
-                connectorConfiguration, "ScyllaAllTypesAvroConnector");
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to register connector.", e);
-      }
-      Assertions.assertEquals(201, returnCode, "Connector registration failed");
-      consumer.subscribe(List.of("canReplicateAllPrimitiveTypesWithAvro.primitive_types_ks.tab"));
-      long startTime = System.currentTimeMillis();
-      boolean messageConsumed = false;
-      while (System.currentTimeMillis() - startTime < 65 * 1000) {
-        var records = consumer.poll(java.time.Duration.ofSeconds(5));
-        if (!records.isEmpty()) {
-          messageConsumed = true;
-          records.forEach(
-              record -> {
-                GenericRecord value = record.value();
-                GenericRecord after = (GenericRecord) value.get("after");
-
-                // Verify all primitive type fields are present and have expected values
-                Assertions.assertEquals("1", extractValue(after.get("id")).toString());
-                Assertions.assertEquals("ascii", extractValue(after.get("ascii_col")).toString());
-                Assertions.assertEquals(
-                    "1234567890123", extractValue(after.get("bigint_col")).toString());
-                Assertions.assertNotNull(extractValue(after.get("blob_col"))); // blob as bytes
-                Assertions.assertEquals("true", extractValue(after.get("boolean_col")).toString());
-                // This is number of days since unix epoch that should correspond to '2024-06-10'
-                Assertions.assertEquals("19884", extractValue(after.get("date_col")).toString());
-                Assertions.assertEquals(
-                    "12345.67", extractValue(after.get("decimal_col")).toString());
-                Assertions.assertEquals(
-                    "3.14159", extractValue(after.get("double_col")).toString());
-                Assertions.assertEquals(
-                    "1d12h30m", extractValue(after.get("duration_col")).toString());
-                Assertions.assertEquals("2.71828", extractValue(after.get("float_col")).toString());
-                Assertions.assertEquals(
-                    "127.0.0.1", extractValue(after.get("inet_col")).toString());
-                Assertions.assertEquals("42", extractValue(after.get("int_col")).toString());
-                Assertions.assertEquals("7", extractValue(after.get("smallint_col")).toString());
-                Assertions.assertEquals(
-                    "some text", extractValue(after.get("text_col")).toString());
-                // Shows up as 45296789000000.
-                // 45296789 part of the value is the number of milliseconds since midnight that
-                // corresponds to '12:34:56.789'
-                Assertions.assertEquals(
-                    "45296789000000", extractValue(after.get("time_col")).toString());
-                // 1718022896789 is unix timestamp in milliseconds for '2024-06-10T12:34:56.789Z'
-                Assertions.assertEquals(
-                    "1718022896789", extractValue(after.get("timestamp_col")).toString());
-                Assertions.assertEquals(
-                    "81d4a030-4632-11f0-9484-409dd8f36eba",
-                    extractValue(after.get("timeuuid_col")).toString());
-                Assertions.assertEquals("5", extractValue(after.get("tinyint_col")).toString());
-                Assertions.assertEquals(
-                    "453662fa-db4b-4938-9033-d8523c0a371c",
-                    extractValue(after.get("uuid_col")).toString());
-                Assertions.assertEquals(
-                    "varchar text", extractValue(after.get("varchar_col")).toString());
-                Assertions.assertEquals(
-                    "999999999", extractValue(after.get("varint_col")).toString());
-              });
-          break;
-        }
-      }
-      consumer.unsubscribe();
-      Assertions.assertTrue(
-          messageConsumed,
-          "No message consumed from the topic. Topic may be empty or connector may have crashed.");
-
-      // The schema registry check is kind of overzealous. The correctness of that part is
-      // mostly the responsibility of the AvroConverter rather than the connector.
-
-      // Verify that schema registry has exactly 1 schema registered for both key and value subjects
-      String topicName = "canReplicateAllPrimitiveTypesWithAvro.primitive_types_ks.tab";
-      String keySubject = topicName + "-key";
-      String valueSubject = topicName + "-value";
-
-      try {
-        String keyVersions = SchemaRegistryUtils.getSchemaVersions(keySubject);
-        String valueVersions = SchemaRegistryUtils.getSchemaVersions(valueSubject);
-
-        Assertions.assertNotNull(keyVersions, "Key subject should exist in schema registry");
-        Assertions.assertNotNull(valueVersions, "Value subject should exist in schema registry");
-
-        Assertions.assertEquals(
-            "[1]", keyVersions, "Key subject should have exactly 1 schema version");
-        Assertions.assertEquals(
-            "[1]", valueVersions, "Key subject should have exactly 1 schema version");
-
-      } catch (Exception e) {
-        Assertions.fail("Failed to verify schema registry: " + e.getMessage());
-      }
-    }
-  }
-
-  /** Condition method for enabling tests that require Confluent Kafka (schema registry). */
-  static boolean isConfluentKafkaProvider() {
-    return KAFKA_PROVIDER == KafkaProvider.CONFLUENT;
-  }
-
-  // Helper method to extract value from Avro types
-  private static Object extractValue(Object obj) {
-    if (obj instanceof GenericRecord) {
-      GenericRecord record = (GenericRecord) obj;
-      return record.get("value");
-    }
-    return obj;
+        """
+        .formatted(
+            beforeJson,
+            afterJson,
+            op,
+            connectorName(testInfo),
+            keyspaceName(testInfo),
+            keyspaceName(testInfo),
+            tableName(testInfo));
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveAvroConnectorIT.java
@@ -1,0 +1,425 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildAvroConnector;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesPrimitiveAvroConnectorIT
+    extends ScyllaTypesPrimitiveBase<GenericRecord, GenericRecord> {
+
+  @BeforeAll
+  static void checkKafkaProvider() {
+    Assumptions.assumeTrue(
+        KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
+    Assumptions.assumeTrue(
+        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
+        "Avro tests require distributed mode, otherwise Avro converter is not available");
+  }
+
+  @Override
+  KafkaConsumer<GenericRecord, GenericRecord> buildConsumer(
+      String connectorName, String tableName) {
+    return buildAvroConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": 1,
+            "ascii_col": {"value": "ascii"},
+            "bigint_col": {"value": 1234567890123},
+            "blob_col": {"value": "Êþº¾"},
+            "boolean_col": {"value": true},
+            "date_col": {"value": 19884},
+            "decimal_col": {"value": "12345.67"},
+            "double_col": {"value": 3.14159},
+            "duration_col": {"value": "1d12h30m"},
+            "float_col": {"value": 2.71828},
+            "inet_col": {"value": "127.0.0.1"},
+            "int_col": {"value": 42},
+            "smallint_col": {"value": 7},
+            "text_col": {"value": "some text"},
+            "time_col": {"value": 45296789000000},
+            "timestamp_col": {"value": 1718022896789},
+            "timeuuid_col": {"value": "81d4a030-4632-11f0-9484-409dd8f36eba"},
+            "tinyint_col": {"value": 5},
+            "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
+            "varchar_col": {"value": "varchar text"},
+            "varint_col": {"value": "999999999"},
+            "untouched_text": {"value": "%s"},
+            "untouched_int": {"value": %d},
+            "untouched_boolean": {"value": %s},
+            "untouched_uuid": {"value": "%s"}
+          },
+          "op": "c",
+          "source": {
+            "connector": "scylla",
+            "name": "%s",
+            "snapshot": "false",
+            "db": "%s",
+            "keyspace_name": "%s",
+            "table_name": "%s"
+          }
+        }
+        """
+          .formatted(
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE,
+              connectorName(testInfo),
+              keyspaceName(testInfo),
+              keyspaceName(testInfo),
+              tableName(testInfo))
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "d",
+          """
+            {
+              "id": 1
+            }
+            """,
+          "null"),
+      null
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "Þ­¾ï"},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii2"},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "Þ­¾ï"},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": "value2"},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": "varchar text 2"},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii"},
+              "bigint_col": {"value": 1234567890123},
+              "blob_col": {"value": "Êþº¾"},
+              "boolean_col": {"value": true},
+              "date_col": {"value": 19884},
+              "decimal_col": {"value": "12345.67"},
+              "double_col": {"value": 3.14159},
+              "duration_col": {"value": "1d12h30m"},
+              "float_col": {"value": 2.71828},
+              "inet_col": {"value": "127.0.0.1"},
+              "int_col": {"value": 42},
+              "smallint_col": {"value": 7},
+              "text_col": {"value": "value"},
+              "time_col": {"value": 45296789000000},
+              "timestamp_col": {"value": 1718022896789},
+              "timeuuid_col": {"value": "81d4a030-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 5},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
+              "varchar_col": {"value": "varchar text"},
+              "varint_col": {"value": "999999999"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "Þ­¾ï"},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii2"},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "Þ­¾ï"},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": "value"},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": "varchar text 2"},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "Þ­¾ï"},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveBase.java
@@ -1,0 +1,335 @@
+package com.scylladb.cdc.debezium.connector;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Integration tests for primitive types replication. Tests simple insert operations with primitive
+ * data types.
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
+public abstract class ScyllaTypesPrimitiveBase<K, V> extends ScyllaTypesIT<K, V> {
+  static final String UNTOUCHED_TEXT_VALUE = "untouched text";
+  static final int UNTOUCHED_INT_VALUE = 101;
+  static final boolean UNTOUCHED_BOOLEAN_VALUE = true;
+  static final String UNTOUCHED_UUID_VALUE = "11111111-1111-1111-1111-111111111111";
+
+  abstract String[] expectedInsert(TestInfo testInfo);
+
+  abstract String[] expectedDelete(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromValueToNil(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromValueToEmpty(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromValueToValue(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromNilToValue(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromNilToEmpty(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromNilToNil(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromEmptyToValue(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromEmptyToNil(TestInfo testInfo);
+
+  abstract String[] expectedUpdateFromEmptyToEmpty(TestInfo testInfo);
+
+  @Override
+  protected String createTableCql(String tableName) {
+    return "("
+        + "id int PRIMARY KEY,"
+        + "ascii_col ascii,"
+        + "bigint_col bigint,"
+        + "blob_col blob,"
+        + "boolean_col boolean,"
+        + "date_col date,"
+        + "decimal_col decimal,"
+        + "double_col double,"
+        + "duration_col duration,"
+        + "float_col float,"
+        + "inet_col inet,"
+        + "int_col int,"
+        + "smallint_col smallint,"
+        + "text_col text,"
+        + "time_col time,"
+        + "timestamp_col timestamp,"
+        + "timeuuid_col timeuuid,"
+        + "tinyint_col tinyint,"
+        + "uuid_col uuid,"
+        + "varchar_col varchar,"
+        + "varint_col varint,"
+        + "untouched_text text,"
+        + "untouched_int int,"
+        + "untouched_boolean boolean,"
+        + "untouched_uuid uuid"
+        + ")";
+  }
+
+  @BeforeAll
+  protected static void setup(TestInfo testInfo) {
+    session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS "
+            + keyspaceName(testInfo)
+            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
+  }
+
+  @Test
+  void testInsert(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'some text', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ")"
+            + ";");
+    String[] expected = expectedInsert(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testDelete(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'delete me', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute("DELETE FROM " + keyspaceTableName(testInfo) + " WHERE id = 1;");
+    String[] expected = expectedDelete(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromValueToNil(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'value', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = null, bigint_col = null, blob_col = null, boolean_col = null, date_col = null, decimal_col = null, double_col = null, duration_col = null, float_col = null, inet_col = null, int_col = null, smallint_col = null, text_col = null, time_col = null, timestamp_col = null, timeuuid_col = null, tinyint_col = null, uuid_col = null, varchar_col = null, varint_col = null WHERE id = 1;");
+    String[] expected = expectedUpdateFromValueToNil(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromValueToEmpty(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'value', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = '', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = '', time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = '', varint_col = 888888888 WHERE id = 1;");
+    String[] expected = expectedUpdateFromValueToEmpty(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromValueToValue(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, 'ascii', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, 'value', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, 'varchar text', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = 'ascii2', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = 'value2', time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = 'varchar text 2', varint_col = 888888888 WHERE id = 1;");
+    String[] expected = expectedUpdateFromValueToValue(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromNilToValue(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES (1, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = 'ascii', bigint_col = 1234567890123, blob_col = 0xCAFEBABE, boolean_col = true, date_col = '2024-06-10', decimal_col = 12345.67, double_col = 3.14159, duration_col = 1d12h30m, float_col = 2.71828, inet_col = '127.0.0.1', int_col = 42, smallint_col = 7, text_col = 'value', time_col = '12:34:56.789', timestamp_col = '2024-06-10T12:34:56.789Z', timeuuid_col = 81d4a030-4632-11f0-9484-409dd8f36eba, tinyint_col = 5, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371c, varchar_col = 'varchar text', varint_col = 999999999 WHERE id = 1;");
+    String[] expected = expectedUpdateFromNilToValue(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromNilToEmpty(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES (1, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = '', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = '', time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = '', varint_col = 888888888 WHERE id = 1;");
+    String[] expected = expectedUpdateFromNilToEmpty(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromNilToNil(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES (1, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = null, bigint_col = null, blob_col = null, boolean_col = null, date_col = null, decimal_col = null, double_col = null, duration_col = null, float_col = null, inet_col = null, int_col = null, smallint_col = null, text_col = null, time_col = null, timestamp_col = null, timeuuid_col = null, tinyint_col = null, uuid_col = null, varchar_col = null, varint_col = null WHERE id = 1;");
+    String[] expected = expectedUpdateFromNilToNil(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromEmptyToValue(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, '', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, '', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, '', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = 'ascii2', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = 'value', time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = 'varchar text 2', varint_col = 888888888 WHERE id = 1;");
+    String[] expected = expectedUpdateFromEmptyToValue(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromEmptyToNil(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, '', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, '', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, '', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = null, bigint_col = null, blob_col = null, boolean_col = null, date_col = null, decimal_col = null, double_col = null, duration_col = null, float_col = null, inet_col = null, int_col = null, smallint_col = null, text_col = null, time_col = null, timestamp_col = null, timeuuid_col = null, tinyint_col = null, uuid_col = null, varchar_col = null, varint_col = null WHERE id = 1;");
+    String[] expected = expectedUpdateFromEmptyToNil(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+
+  @Test
+  void testUpdateFromEmptyToEmpty(TestInfo testInfo) {
+    truncateTables(testInfo);
+    session.execute(
+        "INSERT INTO "
+            + keyspaceTableName(testInfo)
+            + " (id, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, untouched_text, untouched_int, untouched_boolean, untouched_uuid) VALUES ("
+            + "1, '', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, 2.71828, '127.0.0.1', 42, 7, '', '12:34:56.789', '2024-06-10T12:34:56.789Z', 81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, '', 999999999, '"
+            + UNTOUCHED_TEXT_VALUE
+            + "', "
+            + UNTOUCHED_INT_VALUE
+            + ", "
+            + UNTOUCHED_BOOLEAN_VALUE
+            + ", "
+            + UNTOUCHED_UUID_VALUE
+            + ");");
+    session.execute(
+        "UPDATE "
+            + keyspaceTableName(testInfo)
+            + " SET ascii_col = '', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = '', time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = '', varint_col = 888888888 WHERE id = 1;");
+    String[] expected = expectedUpdateFromEmptyToEmpty(testInfo);
+    waitAndAssert(getConsumer(), expected);
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveNewRecordStateConnectorIT.java
@@ -1,0 +1,380 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildScyllaExtractNewRecordStateConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
+    extends ScyllaTypesPrimitiveBase<String, String> {
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildScyllaExtractNewRecordStateConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "id": 1,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "some text",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "id": 1
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToNil(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToEmpty(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "",
+          "varint_col": "888888888"
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToValue(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "ascii2",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "value2",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "varchar text 2",
+          "varint_col": "888888888"
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToValue(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999"
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToEmpty(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "",
+          "varint_col": "888888888"
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToNil(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "ascii2",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "value",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "varchar text 2",
+          "varint_col": "888888888"
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToNil(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null
+        }
+        """
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToEmpty(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+        }
+        """,
+      """
+        {
+          "id": 1,
+          "ascii_col": "",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "",
+          "varint_col": "888888888"
+        }
+        """
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitivePlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitivePlainConnectorIT.java
@@ -1,0 +1,410 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBase<String, String> {
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildPlainConnector(connectorName, tableName);
+  }
+
+  @Override
+  String[] expectedInsert(TestInfo testInfo) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": 1,
+            "ascii_col": {"value": "ascii"},
+            "bigint_col": {"value": 1234567890123},
+            "blob_col": {"value": "yv66vg=="},
+            "boolean_col": {"value": true},
+            "date_col": {"value": 19884},
+            "decimal_col": {"value": "12345.67"},
+            "double_col": {"value": 3.14159},
+            "duration_col": {"value": "1d12h30m"},
+            "float_col": {"value": 2.71828},
+            "inet_col": {"value": "127.0.0.1"},
+            "int_col": {"value": 42},
+            "smallint_col": {"value": 7},
+            "text_col": {"value": "some text"},
+            "time_col": {"value": 45296789000000},
+            "timestamp_col": {"value": 1718022896789},
+            "timeuuid_col": {"value": "81d4a030-4632-11f0-9484-409dd8f36eba"},
+            "tinyint_col": {"value": 5},
+            "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
+            "varchar_col": {"value": "varchar text"},
+            "varint_col": {"value": "999999999"},
+            "untouched_text": {"value": "%s"},
+            "untouched_int": {"value": %d},
+            "untouched_boolean": {"value": %s},
+            "untouched_uuid": {"value": "%s"}
+          },
+          "op": "c",
+          "source": {
+            "connector": "scylla",
+            "name": "%s",
+            "snapshot": "false",
+            "db": "%s",
+            "keyspace_name": "%s",
+            "table_name": "%s"
+          }
+        }
+        """
+          .formatted(
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE,
+              connectorName(testInfo),
+              keyspaceName(testInfo),
+              keyspaceName(testInfo),
+              tableName(testInfo))
+    };
+  }
+
+  @Override
+  String[] expectedDelete(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "d",
+          """
+            {
+              "id": 1
+            }
+            """,
+          "null"),
+      null
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "3q2+7w=="},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii2"},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "3q2+7w=="},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": "value2"},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": "varchar text 2"},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii"},
+              "bigint_col": {"value": 1234567890123},
+              "blob_col": {"value": "yv66vg=="},
+              "boolean_col": {"value": true},
+              "date_col": {"value": 19884},
+              "decimal_col": {"value": "12345.67"},
+              "double_col": {"value": 3.14159},
+              "duration_col": {"value": "1d12h30m"},
+              "float_col": {"value": 2.71828},
+              "inet_col": {"value": "127.0.0.1"},
+              "int_col": {"value": 42},
+              "smallint_col": {"value": 7},
+              "text_col": {"value": "value"},
+              "time_col": {"value": 45296789000000},
+              "timestamp_col": {"value": 1718022896789},
+              "timeuuid_col": {"value": "81d4a030-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 5},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
+              "varchar_col": {"value": "varchar text"},
+              "varint_col": {"value": "999999999"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "3q2+7w=="},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": "ascii2"},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "3q2+7w=="},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": "value"},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": "varchar text 2"},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToNil(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": null},
+              "bigint_col": {"value": null},
+              "blob_col": {"value": null},
+              "boolean_col": {"value": null},
+              "date_col": {"value": null},
+              "decimal_col": {"value": null},
+              "double_col": {"value": null},
+              "duration_col": {"value": null},
+              "float_col": {"value": null},
+              "inet_col": {"value": null},
+              "int_col": {"value": null},
+              "smallint_col": {"value": null},
+              "text_col": {"value": null},
+              "time_col": {"value": null},
+              "timestamp_col": {"value": null},
+              "timeuuid_col": {"value": null},
+              "tinyint_col": {"value": null},
+              "uuid_col": {"value": null},
+              "varchar_col": {"value": null},
+              "varint_col": {"value": null}
+            }
+            """)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToEmpty(TestInfo testInfo) {
+    return new String[] {
+      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord(
+          testInfo,
+          "u",
+          "null",
+          """
+            {
+              "id": 1,
+              "ascii_col": {"value": ""},
+              "bigint_col": {"value": 1234567890124},
+              "blob_col": {"value": "3q2+7w=="},
+              "boolean_col": {"value": false},
+              "date_col": {"value": 19885},
+              "decimal_col": {"value": "98765.43"},
+              "double_col": {"value": 2.71828},
+              "duration_col": {"value": "2d1h"},
+              "float_col": {"value": 1.41421},
+              "inet_col": {"value": "127.0.0.2"},
+              "int_col": {"value": 43},
+              "smallint_col": {"value": 8},
+              "text_col": {"value": ""},
+              "time_col": {"value": 3723456000000},
+              "timestamp_col": {"value": 1718067723456},
+              "timeuuid_col": {"value": "81d4a031-4632-11f0-9484-409dd8f36eba"},
+              "tinyint_col": {"value": 6},
+              "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
+              "varchar_col": {"value": ""},
+              "varint_col": {"value": "888888888"}
+            }
+            """)
+    };
+  }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=10


### PR DESCRIPTION
Add test coverage for all primitive types.
For all combinations of basic connector configurations: plain(org.apache.kafka.connect.json.JsonConverter), io.confluent.connect.avro.AvroConverter and plain+ScyllaExtractNewRecordState, and operations: INSERT, UPDATE, DELETE.

### Test structure changes:
`ScyllaTypesIT` now is a abstract class for suite classes.
Suite class like `ScyllaTypesPrimitiveBase` populates data, and defines test to be run for given suite and then concrete test classes, like `ScyllaTypesPrimitiveAvroConnectorIT`, `ScyllaTypesPrimitiveNewRecordStateConnectorIT` and `ScyllaTypesPrimitivePlainConnectorIT` are implementing connector configuration and expected results for each test. 

### Overall changes:
1. Test are running in parallel, each test has designated connector and table
2. Separate test suits for different connector configurations.
3. Printed logs are limited to avoid OOM
4. Added retry with exponential backoff on connector registrations to make it more stable.
5. Tests on github action now are not failing fast
6. Added tests to cover composite pk
7. Added tests to target different operations