### PR TITLE
cicd: publish test results into run summary

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -9,6 +9,12 @@ jobs:
   run-tests:
     name: "Run integration tests"
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      checks: write
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -67,3 +73,16 @@ jobs:
 
       - name: Maven verify
         run: mvn -B verify -Dit.kafka.provider=${{ matrix.kafka_provider }} -Dit.provider.image.version=${{ matrix.provider_image_version }} -Dit.kafka.connect.mode=${{ matrix.kafka_connect_mode }} -Dit.scylla.version=${{ matrix.scylla_version }}
+
+      - name: Parse test results
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          check_name: Integration test report for ${{ matrix.kafka_provider }}:${{ matrix.provider_image_version }} running in ${{ matrix.kafka_connect_mode }} mode on ScyllaDB ${{ matrix.scylla_version }} version
+          require_tests: false
+          report_paths: "target/*-reports/TEST-*.xml"
+          follow_symlink: true
+          detailed_summary: true
+          updateComment: false
+          # Avoid errors on fork PRs where checks: write is not available
+          annotate_only: true


### PR DESCRIPTION
It provides easy way to get summary on what has failed.