### PR TITLE
test: run one connector per test class

### DIFF
--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkAvroConnectorIT.java
@@ -12,12 +12,14 @@ public class ScyllaCompositePkAvroConnectorIT
     extends ScyllaCompositePkBase<GenericRecord, GenericRecord> {
 
   @BeforeAll
-  static void checkKafkaProvider() {
+  @Override
+  public void setupSuite(TestInfo testInfo) {
     Assumptions.assumeTrue(
         KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
     Assumptions.assumeTrue(
         KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
         "Avro tests require distributed mode, otherwise Avro converter is not available");
+    super.setupSuite(testInfo);
   }
 
   @Override
@@ -27,64 +29,111 @@ public class ScyllaCompositePkAvroConnectorIT
   }
 
   @Override
-  String[] expectedInsert(TestInfo testInfo) {
+  protected int extractPkFromValue(GenericRecord value) {
+    return extractPk1FromRecord(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(GenericRecord key) {
+    return extractPk1FromRecord(key);
+  }
+
+  private int extractPk1FromRecord(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "after" field first (standard Debezium envelope)
+    if (record.getSchema().getField("after") != null) {
+      Object after = record.get("after");
+      if (after instanceof GenericRecord) {
+        GenericRecord afterRecord = (GenericRecord) after;
+        if (afterRecord.getSchema().getField("pk1") != null) {
+          Object pk1 = afterRecord.get("pk1");
+          if (pk1 instanceof Number) {
+            return ((Number) pk1).intValue();
+          }
+        }
+      }
+    }
+    // Try "before" field (for delete operations)
+    if (record.getSchema().getField("before") != null) {
+      Object before = record.get("before");
+      if (before instanceof GenericRecord) {
+        GenericRecord beforeRecord = (GenericRecord) before;
+        if (beforeRecord.getSchema().getField("pk1") != null) {
+          Object pk1 = beforeRecord.get("pk1");
+          if (pk1 instanceof Number) {
+            return ((Number) pk1).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to direct "pk1" field (for keys)
+    if (record.getSchema().getField("pk1") != null) {
+      Object pk1 = record.get("pk1");
+      if (pk1 instanceof Number) {
+        return ((Number) pk1).intValue();
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  String[] expectedInsert(int pk1) {
     return new String[] {
       expectedRecord(
-          testInfo,
           "c",
           "null",
           """
-                {
-                  "pk1": 1,
-                  "pk2": "%s",
-                  "pk3": "%s",
-                  "pk4": 10,
-                  "value_text": {"value": "first"},
-                  "value_int": {"value": 100}
-                }
-                """
-              .formatted(PK2_VALUE, PK3_VALUE))
+            {
+              "pk1": %d,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": %d,
+              "value_text": {"value": "first"},
+              "value_int": {"value": 100}
+            }
+            """
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE))
     };
   }
 
   @Override
-  String[] expectedUpdate(TestInfo testInfo) {
+  String[] expectedUpdate(int pk1) {
     return new String[] {
-      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord("c", "null", "{}"),
       expectedRecord(
-          testInfo,
           "u",
           "null",
           """
-                {
-                  "pk1": 1,
-                  "pk2": "%s",
-                  "pk3": "%s",
-                  "pk4": 10,
-                  "value_text": {"value": "second"},
-                  "value_int": {"value": 200}
-                }
-                """
-              .formatted(PK2_VALUE, PK3_VALUE))
+            {
+              "pk1": %d,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": %d,
+              "value_text": {"value": "second"},
+              "value_int": {"value": 200}
+            }
+            """
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE))
     };
   }
 
   @Override
-  String[] expectedDelete(TestInfo testInfo) {
+  String[] expectedDelete(int pk1) {
     return new String[] {
-      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord("c", "null", "{}"),
       expectedRecord(
-          testInfo,
           "d",
           """
-                {
-                  "pk1": 1,
-                  "pk2": "%s",
-                  "pk3": "%s",
-                  "pk4": 10
-                }
-                """
-              .formatted(PK2_VALUE, PK3_VALUE),
+            {
+              "pk1": %d,
+              "pk2": "%s",
+              "pk3": "%s",
+              "pk4": %d
+            }
+            """
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE),
           "null"),
       null
     };

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkBase.java
@@ -1,26 +1,26 @@
 package com.scylladb.cdc.debezium.connector;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
+/**
+ * Integration tests for composite primary key replication.
+ *
+ * <p>Each test uses a unique pk1 value (obtained via {@link #reservePk()}) for isolation, allowing
+ * all tests to share a single connector and table.
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
 public abstract class ScyllaCompositePkBase<K, V> extends ScyllaTypesIT<K, V> {
   protected static final String PK2_VALUE = "alpha";
   protected static final String PK3_VALUE = "11111111-1111-1111-1111-111111111111";
+  protected static final int PK4_VALUE = 10;
 
-  abstract String[] expectedInsert(TestInfo testInfo);
+  abstract String[] expectedInsert(int pk1);
 
-  abstract String[] expectedUpdate(TestInfo testInfo);
+  abstract String[] expectedUpdate(int pk1);
 
-  abstract String[] expectedDelete(TestInfo testInfo);
-
-  @BeforeAll
-  static void setupKeyspace(TestInfo testInfo) {
-    session.execute(
-        "CREATE KEYSPACE IF NOT EXISTS "
-            + keyspaceName(testInfo)
-            + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
-  }
+  abstract String[] expectedDelete(int pk1);
 
   @Override
   protected String createTableCql(String tableName) {
@@ -36,63 +36,80 @@ public abstract class ScyllaCompositePkBase<K, V> extends ScyllaTypesIT<K, V> {
   }
 
   @Test
-  void testInsertWithMultiColumnPk(TestInfo testInfo) {
-    truncateTables(testInfo);
+  void testInsertWithMultiColumnPk() {
+    int pk1 = reservePk();
     session.execute(
         "INSERT INTO "
-            + keyspaceTableName(testInfo)
+            + getSuiteKeyspaceTableName()
             + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
-            + "1, '"
+            + pk1
+            + ", '"
             + PK2_VALUE
             + "', "
             + PK3_VALUE
-            + ", 10, 'first', 100);");
-    waitAndAssert(getConsumer(), expectedInsert(testInfo));
+            + ", "
+            + PK4_VALUE
+            + ", 'first', 100);");
+    waitAndAssert(pk1, expectedInsert(pk1));
   }
 
   @Test
-  void testUpdateWithMultiColumnPk(TestInfo testInfo) {
-    truncateTables(testInfo);
+  void testUpdateWithMultiColumnPk() {
+    int pk1 = reservePk();
     session.execute(
         "INSERT INTO "
-            + keyspaceTableName(testInfo)
+            + getSuiteKeyspaceTableName()
             + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
-            + "1, '"
+            + pk1
+            + ", '"
             + PK2_VALUE
             + "', "
             + PK3_VALUE
-            + ", 10, 'first', 100);");
+            + ", "
+            + PK4_VALUE
+            + ", 'first', 100);");
     session.execute(
         "UPDATE "
-            + keyspaceTableName(testInfo)
-            + " SET value_text = 'second', value_int = 200 WHERE pk1 = 1 AND pk2 = '"
+            + getSuiteKeyspaceTableName()
+            + " SET value_text = 'second', value_int = 200 WHERE pk1 = "
+            + pk1
+            + " AND pk2 = '"
             + PK2_VALUE
             + "' AND pk3 = "
             + PK3_VALUE
-            + " AND pk4 = 10;");
-    waitAndAssert(getConsumer(), expectedUpdate(testInfo));
+            + " AND pk4 = "
+            + PK4_VALUE
+            + ";");
+    waitAndAssert(pk1, expectedUpdate(pk1));
   }
 
   @Test
-  void testDeleteWithMultiColumnPk(TestInfo testInfo) {
-    truncateTables(testInfo);
+  void testDeleteWithMultiColumnPk() {
+    int pk1 = reservePk();
     session.execute(
         "INSERT INTO "
-            + keyspaceTableName(testInfo)
+            + getSuiteKeyspaceTableName()
             + " (pk1, pk2, pk3, pk4, value_text, value_int) VALUES ("
-            + "1, '"
+            + pk1
+            + ", '"
             + PK2_VALUE
             + "', "
             + PK3_VALUE
-            + ", 10, 'first', 100);");
+            + ", "
+            + PK4_VALUE
+            + ", 'first', 100);");
     session.execute(
         "DELETE FROM "
-            + keyspaceTableName(testInfo)
-            + " WHERE pk1 = 1 AND pk2 = '"
+            + getSuiteKeyspaceTableName()
+            + " WHERE pk1 = "
+            + pk1
+            + " AND pk2 = '"
             + PK2_VALUE
             + "' AND pk3 = "
             + PK3_VALUE
-            + " AND pk4 = 10;");
-    waitAndAssert(getConsumer(), expectedDelete(testInfo));
+            + " AND pk4 = "
+            + PK4_VALUE
+            + ";");
+    waitAndAssert(pk1, expectedDelete(pk1));
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkPlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaCompositePkPlainConnectorIT.java
@@ -3,7 +3,6 @@ package com.scylladb.cdc.debezium.connector;
 import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
 
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.junit.jupiter.api.TestInfo;
 
 public class ScyllaCompositePkPlainConnectorIT extends ScyllaCompositePkBase<String, String> {
 
@@ -13,64 +12,95 @@ public class ScyllaCompositePkPlainConnectorIT extends ScyllaCompositePkBase<Str
   }
 
   @Override
-  String[] expectedInsert(TestInfo testInfo) {
+  protected int extractPkFromValue(String value) {
+    return extractPk1FromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractPk1FromJson(key);
+  }
+
+  private int extractPk1FromJson(String json) {
+    // Parse JSON to extract "pk1" from "after" or root level
+    if (json == null) {
+      return -1;
+    }
+    int pk1Index = json.indexOf("\"pk1\":");
+    if (pk1Index == -1) {
+      return -1;
+    }
+    int start = pk1Index + 6;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  @Override
+  String[] expectedInsert(int pk1) {
     return new String[] {
       expectedRecord(
-          testInfo,
           "c",
           "null",
           """
             {
-              "pk1": 1,
+              "pk1": %d,
               "pk2": "%s",
               "pk3": "%s",
-              "pk4": 10,
+              "pk4": %d,
               "value_text": {"value": "first"},
               "value_int": {"value": 100}
             }
             """
-              .formatted(PK2_VALUE, PK3_VALUE))
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE))
     };
   }
 
   @Override
-  String[] expectedUpdate(TestInfo testInfo) {
+  String[] expectedUpdate(int pk1) {
     return new String[] {
-      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord("c", "null", "{}"),
       expectedRecord(
-          testInfo,
           "u",
           "null",
           """
             {
-              "pk1": 1,
+              "pk1": %d,
               "pk2": "%s",
               "pk3": "%s",
-              "pk4": 10,
+              "pk4": %d,
               "value_text": {"value": "second"},
               "value_int": {"value": 200}
             }
             """
-              .formatted(PK2_VALUE, PK3_VALUE))
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE))
     };
   }
 
   @Override
-  String[] expectedDelete(TestInfo testInfo) {
+  String[] expectedDelete(int pk1) {
     return new String[] {
-      expectedRecord(testInfo, "c", "null", "{}"),
+      expectedRecord("c", "null", "{}"),
       expectedRecord(
-          testInfo,
           "d",
           """
             {
-              "pk1": 1,
+              "pk1": %d,
               "pk2": "%s",
               "pk3": "%s",
-              "pk4": 10
+              "pk4": %d
             }
             """
-              .formatted(PK2_VALUE, PK3_VALUE),
+              .formatted(pk1, PK2_VALUE, PK3_VALUE, PK4_VALUE),
           "null"),
       null
     };


### PR DESCRIPTION
## The goal

Speed up tests execution by running only one connector per test class and creating table also once a class.
Test isolation is done via pk now, instead of table, as it used to be.

## Summary

Redesign integration tests to support parallel execution within each test class while maintaining test isolation through unique primary keys instead of table truncation.

- **Parallel execution**: Add `@TestInstance(PER_CLASS)` and `@Execution(CONCURRENT)` annotations to run tests concurrently
- **PK-based isolation**: Each test reserves a unique primary key via `AtomicInteger.getAndIncrement()`, eliminating the need for table truncation between tests
- **Shared infrastructure**: Single connector and table per test class with background polling thread collecting records into a synchronized list
- **Record filtering**: Tests filter Kafka records by their reserved PK, ensuring isolation without race conditions

