### PR TITLE
Add support for non-frozen collections and UDTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 pom.xml.releaseBackup
 release.properties
 
+TODO.md
+
 # Codex
 .codex/
 .codex-cache/

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSchema.java
@@ -7,7 +7,9 @@ import io.debezium.schema.DataCollectionSchema;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.schema.SchemaNameAdjuster;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,13 +55,26 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
     if (rowSchema == null) {
       return null;
     }
+    LOGGER.info("Computing data collection schema for table: {}", collectionId.getTableName());
 
     boolean includePayloadKey = configuration.getCdcIncludePk().inPayloadKey;
 
     Map<String, Schema> cellSchemas = computeCellSchemas(rowSchema, collectionId);
     Schema keySchema = computeKeySchema(rowSchema, collectionId);
-    Schema beforeSchema = computeRowSchema(rowSchema, cellSchemas, collectionId, "Before");
-    Schema afterSchema = computeRowSchema(rowSchema, cellSchemas, collectionId, "After");
+    Schema beforeSchema =
+        computeRowSchema(
+            rowSchema,
+            cellSchemas,
+            collectionId,
+            "Before",
+            configuration.getCdcIncludePk().inPayloadBefore);
+    Schema afterSchema =
+        computeRowSchema(
+            rowSchema,
+            cellSchemas,
+            collectionId,
+            "After",
+            configuration.getCdcIncludePk().inPayloadAfter);
 
     SchemaBuilder valueSchemaBuilder =
         SchemaBuilder.struct()
@@ -88,6 +103,12 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         .field(Envelope.FieldName.TIMESTAMP_NS, Schema.OPTIONAL_INT64_SCHEMA);
 
     final Schema valueSchema = valueSchemaBuilder.build();
+    LOGGER.info(
+        "Computed value schema for table {}: fields={}",
+        collectionId.getTableName(),
+        valueSchema.fields().stream()
+            .map(f -> f.name() + ":" + f.schema().type())
+            .collect(Collectors.joining(", ")));
     final Envelope envelope = Envelope.fromSchema(valueSchema);
 
     return new ScyllaCollectionSchema(
@@ -105,14 +126,28 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
   private Map<String, Schema> computeCellSchemas(
       ChangeSchema changeSchema, CollectionId collectionId) {
     Map<String, Schema> cellSchemas = new HashMap<>();
+    String schemaNamePrefix = generateSchemaNamePrefix(collectionId);
     for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
-      ChangeSchema.ColumnType colType = cdef.getBaseTableColumnType();
-      if (colType == ChangeSchema.ColumnType.PARTITION_KEY
-          || colType == ChangeSchema.ColumnType.CLUSTERING_KEY) continue;
-      if (!isSupportedColumnSchema(cdef)) continue;
+      if (isPrimaryKeyColumn(cdef)) continue;
 
-      Schema columnSchema = computeColumnSchema(cdef);
-      cellSchemas.put(cdef.getColumnName(), columnSchema);
+      try {
+        Schema columnSchema =
+            computeColumnSchema(
+                cdef.getCdcLogDataType(), cdef.getBaseTableDataType(), schemaNamePrefix);
+        cellSchemas.put(cdef.getColumnName(), columnSchema);
+        LOGGER.debug(
+            "Computed cell schema for column {}: type={}, schema={}",
+            cdef.getColumnName(),
+            cdef.getCdcLogDataType().getCqlType(),
+            columnSchema);
+      } catch (Exception e) {
+        LOGGER.error(
+            "Failed to compute cell schema for column {}: type={}",
+            cdef.getColumnName(),
+            cdef.getCdcLogDataType().getCqlType(),
+            e);
+        throw e;
+      }
     }
     return cellSchemas;
   }
@@ -125,31 +160,21 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
     }
 
     SchemaBuilder keySchemaBuilder =
-        SchemaBuilder.struct()
-            .name(
-                adjuster.adjust(
-                    configuration.getLogicalName()
-                        + "."
-                        + collectionId.getTableName().keyspace
-                        + "."
-                        + collectionId.getTableName().name
-                        + ".Key"));
+        SchemaBuilder.struct().name(generateSchemaNamePrefix(collectionId) + "Key");
 
     // Add partition key columns first to ensure proper primary key ordering
     for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
       if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.PARTITION_KEY) continue;
-      if (!isSupportedColumnSchema(cdef)) continue;
 
-      Schema columnSchema = computeColumnSchema(cdef);
+      Schema columnSchema = computeColumnSchema(cdef.getCdcLogDataType());
       keySchemaBuilder = keySchemaBuilder.field(cdef.getColumnName(), columnSchema);
     }
 
     // Add clustering key columns second
     for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
       if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.CLUSTERING_KEY) continue;
-      if (!isSupportedColumnSchema(cdef)) continue;
 
-      Schema columnSchema = computeColumnSchema(cdef);
+      Schema columnSchema = computeColumnSchema(cdef.getCdcLogDataType());
       keySchemaBuilder = keySchemaBuilder.field(cdef.getColumnName(), columnSchema);
     }
 
@@ -158,73 +183,122 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
     return keySchema;
   }
 
-  private String generateSchemaName(CollectionId collectionId, String suffix) {
+  /**
+   * Generates a schema name prefix for nested types (maps, tuples, UDTs).
+   *
+   * <p>This prefix ensures globally unique schema names across different topics, which is required
+   * when using Schema Registry with {@code RecordNameStrategy}. Without this prefix, two different
+   * tables with the same nested type structure (e.g., {@code map<text, int>}) would generate
+   * identical schema names like {@code MapEntry_TEXT_INT}, causing conflicts if the structures
+   * differ or when schema evolution occurs independently per table.
+   *
+   * <p>With this prefix, schemas are namespaced per table: {@code
+   * connector.keyspace.table.MapEntry_TEXT_INT}
+   *
+   * @param collectionId the collection (table) identifier
+   * @return the schema name prefix including trailing dot
+   */
+  private String generateSchemaNamePrefix(CollectionId collectionId) {
     return adjuster.adjust(
-        configuration.getLogicalName()
-            + "."
-            + collectionId.getTableName().keyspace
-            + "."
-            + collectionId.getTableName().name
-            + "."
-            + suffix);
+            configuration.getLogicalName()
+                + "."
+                + collectionId.getTableName().keyspace
+                + "."
+                + collectionId.getTableName().name)
+        + ".";
   }
 
   private Schema computeRowSchema(
       ChangeSchema changeSchema,
       Map<String, Schema> cellSchemas,
       CollectionId collectionId,
-      String suffix) {
+      String suffix,
+      boolean includePk) {
     SchemaBuilder schemaBuilder =
-        SchemaBuilder.struct().name(generateSchemaName(collectionId, suffix));
+        SchemaBuilder.struct().name(generateSchemaNamePrefix(collectionId) + suffix);
     for (ChangeSchema.ColumnDefinition cdef : changeSchema.getNonCdcColumnDefinitions()) {
-      if (!isSupportedColumnSchema(cdef)) continue;
-
-      if (cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.PARTITION_KEY
-          && cdef.getBaseTableColumnType() != ChangeSchema.ColumnType.CLUSTERING_KEY) {
+      if (isPrimaryKeyColumn(cdef)) {
+        if (includePk) {
+          Schema columnSchema = computeColumnSchema(cdef.getCdcLogDataType());
+          schemaBuilder = schemaBuilder.field(cdef.getColumnName(), columnSchema);
+        }
+      } else {
         schemaBuilder =
             schemaBuilder.field(cdef.getColumnName(), cellSchemas.get(cdef.getColumnName()));
-      } else {
-        Schema columnSchema = computeColumnSchema(cdef);
-        schemaBuilder = schemaBuilder.field(cdef.getColumnName(), columnSchema);
       }
     }
     return schemaBuilder.optional().build();
   }
 
-  private Schema computeColumnSchema(ChangeSchema.ColumnDefinition cdef) {
-    switch (cdef.getCdcLogDataType().getCqlType()) {
-      case ASCII:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case BIGINT:
-        return Schema.OPTIONAL_INT64_SCHEMA;
-      case BLOB:
-        return Schema.OPTIONAL_BYTES_SCHEMA;
-      case BOOLEAN:
-        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
-      case COUNTER:
-        return Schema.OPTIONAL_INT64_SCHEMA;
-      case DECIMAL:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case DOUBLE:
-        return Schema.OPTIONAL_FLOAT64_SCHEMA;
-      case FLOAT:
-        return Schema.OPTIONAL_FLOAT32_SCHEMA;
-      case INT:
-        return Schema.OPTIONAL_INT32_SCHEMA;
-      case TEXT:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case TIMESTAMP:
-        return Timestamp.builder().optional().build();
-      case UUID:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case VARCHAR:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case VARINT:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case TIMEUUID:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case INET:
-        return Schema.OPTIONAL_STRING_SCHEMA;
+  /**
+   * Generates a unique schema name for a CQL data type.
+   *
+   * <p>Avro requires all record types to have unique names. This method generates deterministic
+   * names based on the type structure.
+   */
+  private static String generateTypeName(ChangeSchema.DataType dataType) {
+    if (dataType == null) {
+      return "Unknown";
+    }
+    ChangeSchema.CqlType cqlType = dataType.getCqlType();
+    switch (cqlType) {
+      case MAP:
+        List<ChangeSchema.DataType> mapArgs = dataType.getTypeArguments();
+        if (mapArgs != null && mapArgs.size() == 2) {
+          return "Map_" + generateTypeName(mapArgs.get(0)) + "_" + generateTypeName(mapArgs.get(1));
+        }
+        return "Map";
+      case LIST:
+        List<ChangeSchema.DataType> listArgs = dataType.getTypeArguments();
+        if (listArgs != null && !listArgs.isEmpty()) {
+          return "List_" + generateTypeName(listArgs.get(0));
+        }
+        return "List";
+      case SET:
+        List<ChangeSchema.DataType> setArgs = dataType.getTypeArguments();
+        if (setArgs != null && !setArgs.isEmpty()) {
+          return "Set_" + generateTypeName(setArgs.get(0));
+        }
+        return "Set";
+      case TUPLE:
+        List<ChangeSchema.DataType> tupleArgs = dataType.getTypeArguments();
+        if (tupleArgs != null && !tupleArgs.isEmpty()) {
+          StringBuilder sb = new StringBuilder("Tuple");
+          for (ChangeSchema.DataType arg : tupleArgs) {
+            sb.append("_").append(generateTypeName(arg));
+          }
+          return sb.toString();
+        }
+        return "Tuple";
+      case UDT:
+        ChangeSchema.DataType.UdtType udtType = dataType.getUdtType();
+        if (udtType != null && udtType.getName() != null) {
+          // Sanitize UDT name for Avro (replace dots and other invalid chars)
+          return "UDT_" + udtType.getName().replace(".", "_").replace("-", "_");
+        }
+        return "UDT";
+      default:
+        return cqlType.name();
+    }
+  }
+
+  /**
+   * Computes a Kafka Connect schema for a scalar or frozen collection type.
+   *
+   * <p>For top-level columns, baseTableType is used to distinguish non-frozen lists (which are
+   * stored as map&lt;timeuuid, V&gt; in the CDC log) from frozen maps with timeuuid keys. For
+   * nested types, baseTableType should be null (nested types are always frozen).
+   *
+   * @param cdcLogType the data type as it appears in the CDC log
+   * @param baseTableType the data type in the base table (used to distinguish non-frozen lists)
+   * @param schemaNamePrefix prefix for nested struct schema names (e.g., "connector.ks.table.") to
+   *     ensure global uniqueness across topics when using RecordNameStrategy
+   */
+  private static Schema computeColumnSchema(
+      ChangeSchema.DataType cdcLogType,
+      ChangeSchema.DataType baseTableType,
+      String schemaNamePrefix) {
+    switch (cdcLogType.getCqlType()) {
       case DATE:
         return Date.builder().optional().build();
       case TIME:
@@ -238,25 +312,156 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
         return Schema.OPTIONAL_INT16_SCHEMA;
       case TINYINT:
         return Schema.OPTIONAL_INT8_SCHEMA;
+      case BLOB:
+        return Schema.OPTIONAL_BYTES_SCHEMA;
+      case BOOLEAN:
+        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
+      case DOUBLE:
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
+      case FLOAT:
+        return Schema.OPTIONAL_FLOAT32_SCHEMA;
+      case INT:
+        return Schema.OPTIONAL_INT32_SCHEMA;
+      case TIMESTAMP:
+        return Timestamp.builder().optional().build();
+      case BIGINT:
+      case COUNTER:
+        return Schema.OPTIONAL_INT64_SCHEMA;
+      case ASCII:
+      case DECIMAL:
+      case UUID:
+      case VARCHAR:
+      case VARINT:
+      case TIMEUUID:
+      case INET:
       case DURATION:
+      case TEXT:
         return Schema.OPTIONAL_STRING_SCHEMA;
-      case LIST:
-      case MAP:
       case SET:
-      case UDT:
+      case LIST:
+        {
+          List<ChangeSchema.DataType> typeArgs = cdcLogType.getTypeArguments();
+          if (typeArgs == null || typeArgs.isEmpty()) {
+            throw new IllegalStateException(
+                cdcLogType.getCqlType() + " type must have exactly 1 type argument");
+          }
+          Schema innerSchema = computeColumnSchema(typeArgs.get(0), null, schemaNamePrefix);
+          return SchemaBuilder.array(innerSchema).optional().build();
+        }
+      case MAP:
+        {
+          List<ChangeSchema.DataType> typeArgs = cdcLogType.getTypeArguments();
+          if (typeArgs == null || typeArgs.size() != 2) {
+            throw new IllegalStateException("MAP type must have exactly 2 type arguments");
+          }
+          // Check if this is a non-frozen list (stored as map<timeuuid, V> in CDC log).
+          // Non-frozen lists have TIMEUUID keys AND base table type is LIST.
+          // Without the base table type check, frozen map<timeuuid, V> would be
+          // incorrectly treated as a non-frozen list.
+          boolean isNonFrozenList =
+              baseTableType != null
+                  && baseTableType.getCqlType() == ChangeSchema.CqlType.LIST
+                  && typeArgs.get(0).getCqlType() == ChangeSchema.CqlType.TIMEUUID;
+
+          if (isNonFrozenList) {
+            Schema valueSchema = computeColumnSchema(typeArgs.get(1), null, schemaNamePrefix);
+            return SchemaBuilder.array(valueSchema).optional().build();
+          }
+
+          Schema keySchema = computeColumnSchema(typeArgs.get(0), null, schemaNamePrefix);
+          Schema valueSchema = computeColumnSchema(typeArgs.get(1), null, schemaNamePrefix);
+          // Generate a unique name for the map entry struct based on key/value types.
+          // The schemaNamePrefix ensures global uniqueness across topics when using
+          // RecordNameStrategy in Schema Registry.
+          String entrySchemaName =
+              schemaNamePrefix
+                  + "MapEntry_"
+                  + generateTypeName(typeArgs.get(0))
+                  + "_"
+                  + generateTypeName(typeArgs.get(1));
+          Schema entrySchema =
+              SchemaBuilder.struct()
+                  .name(entrySchemaName)
+                  .field("key", keySchema)
+                  .field("value", valueSchema)
+                  .build();
+          return SchemaBuilder.array(entrySchema).optional().build();
+        }
       case TUPLE:
+        {
+          List<Schema> innerSchemas =
+              cdcLogType.getTypeArguments().stream()
+                  .map(arg -> computeColumnSchema(arg, null, schemaNamePrefix))
+                  .collect(Collectors.toList());
+          // Generate a unique name for the tuple struct based on field types.
+          // The schemaNamePrefix ensures global uniqueness across topics.
+          String tupleSchemaName = schemaNamePrefix + generateTypeName(cdcLogType);
+          SchemaBuilder tupleSchema = SchemaBuilder.struct().name(tupleSchemaName);
+          for (int i = 0; i < innerSchemas.size(); i++) {
+            // Use "field_N" naming for Avro compatibility (Avro field names cannot start with
+            // digits)
+            tupleSchema = tupleSchema.field("field_" + i, innerSchemas.get(i));
+          }
+          return tupleSchema.optional().build();
+        }
+      case UDT:
+        {
+          ChangeSchema.DataType udtDataType = unwrapUdtElementsType(cdcLogType);
+          ChangeSchema.DataType.UdtType udt = udtDataType.getUdtType();
+          if (udt == null || udt.getFields() == null) {
+            throw new IllegalStateException("UDT type must have non-null UdtType with fields");
+          }
+          // Generate a unique name for the UDT struct based on its name.
+          // The schemaNamePrefix ensures global uniqueness across topics, which is critical
+          // for UDTs since different keyspaces may have UDTs with the same name but different
+          // structures.
+          String udtSchemaName = schemaNamePrefix + generateTypeName(udtDataType);
+          SchemaBuilder udtSchema = SchemaBuilder.struct().name(udtSchemaName);
+          for (Map.Entry<String, ChangeSchema.DataType> field : udt.getFields().entrySet()) {
+            udtSchema =
+                udtSchema.field(
+                    field.getKey(), computeColumnSchema(field.getValue(), null, schemaNamePrefix));
+          }
+          return udtSchema.optional().build();
+        }
       default:
         throw new UnsupportedOperationException();
     }
   }
 
-  protected static boolean isSupportedColumnSchema(ChangeSchema.ColumnDefinition cdef) {
-    ChangeSchema.CqlType type = cdef.getCdcLogDataType().getCqlType();
-    return type != ChangeSchema.CqlType.LIST
-        && type != ChangeSchema.CqlType.MAP
-        && type != ChangeSchema.CqlType.SET
-        && type != ChangeSchema.CqlType.UDT
-        && type != ChangeSchema.CqlType.TUPLE;
+  /**
+   * Computes a Kafka Connect schema for primary key columns.
+   *
+   * <p>Primary key columns are always scalar types and don't need a schema name prefix since they
+   * don't create nested struct schemas.
+   */
+  private static Schema computeColumnSchema(ChangeSchema.DataType type) {
+    return computeColumnSchema(type, null, "");
+  }
+
+  private static ChangeSchema.DataType unwrapUdtElementsType(ChangeSchema.DataType type) {
+    if (type.getCqlType() != ChangeSchema.CqlType.UDT) {
+      return type;
+    }
+    ChangeSchema.DataType.UdtType udtType = type.getUdtType();
+    if (udtType == null) {
+      return type;
+    }
+    Map<String, ChangeSchema.DataType> fields = udtType.getFields();
+    if (fields != null && fields.size() == 1 && fields.containsKey("elements")) {
+      ChangeSchema.DataType elementsType = fields.get("elements");
+      if (elementsType != null && elementsType.getCqlType() == ChangeSchema.CqlType.UDT) {
+        return elementsType;
+      }
+    }
+    return type;
+  }
+
+  /** Checks if the column is a primary key column (partition key or clustering key). */
+  private static boolean isPrimaryKeyColumn(ChangeSchema.ColumnDefinition cdef) {
+    ChangeSchema.ColumnType colType = cdef.getBaseTableColumnType();
+    return colType == ChangeSchema.ColumnType.PARTITION_KEY
+        || colType == ChangeSchema.ColumnType.CLUSTERING_KEY;
   }
 
   public ScyllaCollectionSchema updateChangeSchema(
@@ -264,16 +469,6 @@ public class ScyllaSchema implements DatabaseSchema<CollectionId> {
     cdcRowSchemas.put(collectionId, cdcRowSchema);
     dataCollectionSchemas.put(collectionId, computeDataCollectionSchema(collectionId));
     return dataCollectionSchemas.get(collectionId);
-  }
-
-  /**
-   * Returns the cached key schema for the given keyspace.table, or null if not cached.
-   *
-   * @param collectionId the collection ID (keyspace.table)
-   * @return the cached key schema, or null if not yet computed
-   */
-  public Schema getKeySchema(CollectionId collectionId) {
-    return keySchemaCache.get(collectionId);
   }
 
   @Override

--- a/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ScyllaExtractNewRecordState.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ScyllaExtractNewRecordState.java
@@ -236,7 +236,7 @@ public class ScyllaExtractNewRecordState<R extends ConnectRecord<R>>
       builder.defaultValue(schema.defaultValue());
     }
     if (schema.parameters() != null) {
-      for (java.util.Map.Entry<String, String> entry : schema.parameters().entrySet()) {
+      for (Map.Entry<String, String> entry : schema.parameters().entrySet()) {
         builder.parameter(entry.getKey(), entry.getValue());
       }
     }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeAfterBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeAfterBase.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
  * only-updated).
  *
  * <p>The table schema includes multiple columns to properly test the "only-updated" mode, which
- * should only include modified columns in before/after structs for UPDATE operations.
+ * should only include modified columns in before/after structs for UPDATE operations. Every type
+ * has an "untouched_" counterpart that is set on INSERT but never modified, to verify that
+ * only-updated mode correctly excludes unchanged columns.
  *
  * <p>Each test uses a unique primary key (obtained via {@link #reservePk()}) for isolation,
  * allowing all tests to share a single connector and table.
@@ -22,6 +24,56 @@ import org.junit.jupiter.api.Test;
  * @param <V> the type of the Kafka consumer value
  */
 public abstract class CdcIncludeBeforeAfterBase<K, V> extends ScyllaTypesIT<K, V> {
+
+  // ===================== Untouched Column Values =====================
+  // These values are set on INSERT and never modified during UPDATE operations.
+
+  static final String UNTOUCHED_ASCII = "untouched_ascii";
+  static final long UNTOUCHED_BIGINT = 9999999999999L;
+  static final String UNTOUCHED_BLOB_HEX = "0xDEADCAFE";
+  static final boolean UNTOUCHED_BOOLEAN = true;
+  static final String UNTOUCHED_DATE = "2020-01-01";
+  static final String UNTOUCHED_DECIMAL = "99999.99";
+  static final double UNTOUCHED_DOUBLE = 9.99999;
+  static final String UNTOUCHED_DURATION = "9d9h9m";
+  static final float UNTOUCHED_FLOAT = 9.99f;
+  static final String UNTOUCHED_INET = "192.168.1.1";
+  static final int UNTOUCHED_INT = 99999;
+  static final short UNTOUCHED_SMALLINT = 999;
+  static final String UNTOUCHED_TEXT = "untouched_text";
+  static final String UNTOUCHED_TIME = "09:09:09.999";
+  static final String UNTOUCHED_TIMESTAMP = "2020-01-01T09:09:09.999Z";
+  static final String UNTOUCHED_TIMEUUID = "a1a1a1a1-a1a1-11f0-a1a1-a1a1a1a1a1a1";
+  static final byte UNTOUCHED_TINYINT = 99;
+  static final String UNTOUCHED_UUID = "99999999-9999-9999-9999-999999999999";
+  static final String UNTOUCHED_VARCHAR = "untouched_varchar";
+  static final String UNTOUCHED_VARINT = "9999999999";
+  // Untouched collections
+  static final String UNTOUCHED_LIST = "[999, 998, 997]";
+  static final String UNTOUCHED_SET = "{'untouched_a', 'untouched_b'}";
+  static final String UNTOUCHED_MAP = "{999: 'untouched_val'}";
+  static final String UNTOUCHED_FROZEN_LIST = "[999, 998]";
+  static final String UNTOUCHED_FROZEN_SET = "{'untouched_x', 'untouched_y'}";
+  static final String UNTOUCHED_FROZEN_MAP = "{999: 'untouched_frozen'}";
+  static final String UNTOUCHED_FROZEN_TUPLE = "(999, 'untouched_tuple')";
+  // Untouched UDTs
+  static final String UNTOUCHED_FROZEN_UDT = "{a: 999, b: 'untouched_udt'}";
+  static final String UNTOUCHED_NF_UDT = "{a: 998, b: 'untouched_nf_udt'}";
+  static final String UNTOUCHED_FROZEN_NESTED_UDT =
+      "{inner: {x: 999, y: 'untouched_inner'}, z: 999}";
+  static final String UNTOUCHED_NF_NESTED_UDT =
+      "{inner: {x: 998, y: 'untouched_nf_inner'}, z: 998}";
+  static final String UNTOUCHED_FROZEN_UDT_WITH_MAP =
+      "{m: {81d4a034-4632-11f0-9484-409dd8f36eba: 'untouched_value'}}";
+  static final String UNTOUCHED_NF_UDT_WITH_MAP =
+      "{m: {81d4a035-4632-11f0-9484-409dd8f36eba: 'untouched_nf_value'}}";
+  static final String UNTOUCHED_FROZEN_UDT_WITH_LIST = "{l: [999, 998]}";
+  static final String UNTOUCHED_NF_UDT_WITH_LIST = "{l: [997, 996]}";
+  static final String UNTOUCHED_FROZEN_UDT_WITH_SET = "{s: {'untouched_set_a', 'untouched_set_b'}}";
+  static final String UNTOUCHED_NF_UDT_WITH_SET =
+      "{s: {'untouched_nf_set_a', 'untouched_nf_set_b'}}";
+
+  // ===================== Abstract Methods =====================
 
   /**
    * Returns the expected JSON for an INSERT operation with the given primary key. Implementations
@@ -50,21 +102,310 @@ public abstract class CdcIncludeBeforeAfterBase<K, V> extends ScyllaTypesIT<K, V
    */
   abstract String[] expectedUpdateMultiColumn(int pk);
 
+  // ===================== Schema Definition =====================
+
   /**
-   * Table schema with multiple columns to test before/after modes properly. The schema includes: -
-   * id: primary key - name: text column (used for test identification and single-column updates) -
-   * value: integer column (used to test multi-column updates)
+   * Creates UDT types before table creation (from ScyllaTypesUDTBase).
+   *
+   * @param keyspaceName the keyspace name
    */
   @Override
-  protected String createTableCql(String tableName) {
-    return "(id int PRIMARY KEY, name text, value int)";
+  protected void createTypesBeforeTable(String keyspaceName) {
+    session.execute("CREATE TYPE IF NOT EXISTS " + keyspaceName + ".simple_udt (a int, b text);");
+    session.execute("CREATE TYPE IF NOT EXISTS " + keyspaceName + ".inner_udt (x int, y text);");
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS "
+            + keyspaceName
+            + ".nested_udt (inner frozen<inner_udt>, z int);");
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS "
+            + keyspaceName
+            + ".udt_with_map (m frozen<map<timeuuid, text>>);");
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS " + keyspaceName + ".udt_with_list (l frozen<list<int>>);");
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS " + keyspaceName + ".udt_with_set (s frozen<set<text>>);");
   }
 
   /**
+   * Table schema with all supported data types. Each type has both an active column (modified in
+   * tests) and an untouched counterpart (set once on INSERT, never modified).
+   */
+  @Override
+  protected String createTableCql(String tableName) {
+    return "("
+        + "id int PRIMARY KEY,"
+        // Primitive types - active columns
+        + "ascii_col ascii,"
+        + "bigint_col bigint,"
+        + "blob_col blob,"
+        + "boolean_col boolean,"
+        + "date_col date,"
+        + "decimal_col decimal,"
+        + "double_col double,"
+        + "duration_col duration,"
+        + "float_col float,"
+        + "inet_col inet,"
+        + "int_col int,"
+        + "smallint_col smallint,"
+        + "text_col text,"
+        + "time_col time,"
+        + "timestamp_col timestamp,"
+        + "timeuuid_col timeuuid,"
+        + "tinyint_col tinyint,"
+        + "uuid_col uuid,"
+        + "varchar_col varchar,"
+        + "varint_col varint,"
+        // Primitive types - untouched columns
+        + "untouched_ascii ascii,"
+        + "untouched_bigint bigint,"
+        + "untouched_blob blob,"
+        + "untouched_boolean boolean,"
+        + "untouched_date date,"
+        + "untouched_decimal decimal,"
+        + "untouched_double double,"
+        + "untouched_duration duration,"
+        + "untouched_float float,"
+        + "untouched_inet inet,"
+        + "untouched_int int,"
+        + "untouched_smallint smallint,"
+        + "untouched_text text,"
+        + "untouched_time time,"
+        + "untouched_timestamp timestamp,"
+        + "untouched_timeuuid timeuuid,"
+        + "untouched_tinyint tinyint,"
+        + "untouched_uuid uuid,"
+        + "untouched_varchar varchar,"
+        + "untouched_varint varint,"
+        // Non-frozen collections - active columns
+        + "list_col list<int>,"
+        + "set_col set<text>,"
+        + "map_col map<int, text>,"
+        // Non-frozen collections - untouched columns
+        + "untouched_list list<int>,"
+        + "untouched_set set<text>,"
+        + "untouched_map map<int, text>,"
+        // Frozen collections - active columns
+        + "frozen_list_col frozen<list<int>>,"
+        + "frozen_set_col frozen<set<text>>,"
+        + "frozen_map_col frozen<map<int, text>>,"
+        + "frozen_tuple_col frozen<tuple<int, text>>,"
+        // Frozen collections - untouched columns
+        + "untouched_frozen_list frozen<list<int>>,"
+        + "untouched_frozen_set frozen<set<text>>,"
+        + "untouched_frozen_map frozen<map<int, text>>,"
+        + "untouched_frozen_tuple frozen<tuple<int, text>>,"
+        // UDTs - active columns
+        + "frozen_udt frozen<simple_udt>,"
+        + "nf_udt simple_udt,"
+        + "frozen_nested_udt frozen<nested_udt>,"
+        + "nf_nested_udt nested_udt,"
+        + "frozen_udt_with_map frozen<udt_with_map>,"
+        + "nf_udt_with_map udt_with_map,"
+        + "frozen_udt_with_list frozen<udt_with_list>,"
+        + "nf_udt_with_list udt_with_list,"
+        + "frozen_udt_with_set frozen<udt_with_set>,"
+        + "nf_udt_with_set udt_with_set,"
+        // UDTs - untouched columns
+        + "untouched_frozen_udt frozen<simple_udt>,"
+        + "untouched_nf_udt simple_udt,"
+        + "untouched_frozen_nested_udt frozen<nested_udt>,"
+        + "untouched_nf_nested_udt nested_udt,"
+        + "untouched_frozen_udt_with_map frozen<udt_with_map>,"
+        + "untouched_nf_udt_with_map udt_with_map,"
+        + "untouched_frozen_udt_with_list frozen<udt_with_list>,"
+        + "untouched_nf_udt_with_list udt_with_list,"
+        + "untouched_frozen_udt_with_set frozen<udt_with_set>,"
+        + "untouched_nf_udt_with_set udt_with_set"
+        + ")";
+  }
+
+  // ===================== CQL Column Lists =====================
+
+  /** All column names for INSERT operations. */
+  private static final String ALL_COLUMNS =
+      "id, "
+          // Primitive types - active
+          + "ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, "
+          + "duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, "
+          + "timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col, "
+          // Primitive types - untouched
+          + "untouched_ascii, untouched_bigint, untouched_blob, untouched_boolean, untouched_date, "
+          + "untouched_decimal, untouched_double, untouched_duration, untouched_float, "
+          + "untouched_inet, untouched_int, untouched_smallint, untouched_text, untouched_time, "
+          + "untouched_timestamp, untouched_timeuuid, untouched_tinyint, untouched_uuid, "
+          + "untouched_varchar, untouched_varint, "
+          // Non-frozen collections - active
+          + "list_col, set_col, map_col, "
+          // Non-frozen collections - untouched
+          + "untouched_list, untouched_set, untouched_map, "
+          // Frozen collections - active
+          + "frozen_list_col, frozen_set_col, frozen_map_col, frozen_tuple_col, "
+          // Frozen collections - untouched
+          + "untouched_frozen_list, untouched_frozen_set, untouched_frozen_map, "
+          + "untouched_frozen_tuple, "
+          // UDTs - active
+          + "frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, frozen_udt_with_map, "
+          + "nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, frozen_udt_with_set, "
+          + "nf_udt_with_set, "
+          // UDTs - untouched
+          + "untouched_frozen_udt, untouched_nf_udt, untouched_frozen_nested_udt, "
+          + "untouched_nf_nested_udt, untouched_frozen_udt_with_map, untouched_nf_udt_with_map, "
+          + "untouched_frozen_udt_with_list, untouched_nf_udt_with_list, "
+          + "untouched_frozen_udt_with_set, untouched_nf_udt_with_set";
+
+  // ===================== CQL Value Sets =====================
+
+  /** Values for active primitive columns (set 1 - initial values). */
+  private static final String PRIMITIVE_VALUES_SET1 =
+      "'ascii_val', 1234567890123, 0xCAFEBABE, true, '2024-06-10', 12345.67, 3.14159, 1d12h30m, "
+          + "2.71828, '127.0.0.1', 42, 7, 'text_val', '12:34:56.789', '2024-06-10T12:34:56.789Z', "
+          + "81d4a030-4632-11f0-9484-409dd8f36eba, 5, 453662fa-db4b-4938-9033-d8523c0a371c, "
+          + "'varchar_val', 999999999";
+
+  /** Values for untouched primitive columns (never modified). */
+  private static final String UNTOUCHED_PRIMITIVE_VALUES =
+      "'"
+          + UNTOUCHED_ASCII
+          + "', "
+          + UNTOUCHED_BIGINT
+          + ", "
+          + UNTOUCHED_BLOB_HEX
+          + ", "
+          + UNTOUCHED_BOOLEAN
+          + ", '"
+          + UNTOUCHED_DATE
+          + "', "
+          + UNTOUCHED_DECIMAL
+          + ", "
+          + UNTOUCHED_DOUBLE
+          + ", "
+          + UNTOUCHED_DURATION
+          + ", "
+          + UNTOUCHED_FLOAT
+          + ", '"
+          + UNTOUCHED_INET
+          + "', "
+          + UNTOUCHED_INT
+          + ", "
+          + UNTOUCHED_SMALLINT
+          + ", '"
+          + UNTOUCHED_TEXT
+          + "', '"
+          + UNTOUCHED_TIME
+          + "', '"
+          + UNTOUCHED_TIMESTAMP
+          + "', "
+          + UNTOUCHED_TIMEUUID
+          + ", "
+          + UNTOUCHED_TINYINT
+          + ", "
+          + UNTOUCHED_UUID
+          + ", '"
+          + UNTOUCHED_VARCHAR
+          + "', "
+          + UNTOUCHED_VARINT;
+
+  /** Values for active non-frozen collections (set 1). */
+  private static final String NF_COLLECTION_VALUES_SET1 =
+      "[10, 20, 30], {'x', 'y', 'z'}, {1: 'one', 2: 'two'}";
+
+  /** Values for untouched non-frozen collections. */
+  private static final String UNTOUCHED_NF_COLLECTION_VALUES =
+      UNTOUCHED_LIST + ", " + UNTOUCHED_SET + ", " + UNTOUCHED_MAP;
+
+  /** Values for active frozen collections (set 1). */
+  private static final String FROZEN_COLLECTION_VALUES_SET1 =
+      "[100, 200], {'p', 'q'}, {10: 'ten'}, (1, 'tuple1')";
+
+  /** Values for untouched frozen collections. */
+  private static final String UNTOUCHED_FROZEN_COLLECTION_VALUES =
+      UNTOUCHED_FROZEN_LIST
+          + ", "
+          + UNTOUCHED_FROZEN_SET
+          + ", "
+          + UNTOUCHED_FROZEN_MAP
+          + ", "
+          + UNTOUCHED_FROZEN_TUPLE;
+
+  /** Values for active UDTs (set 1). */
+  private static final String UDT_VALUES_SET1 =
+      "{a: 42, b: 'foo'}, "
+          + "{a: 7, b: 'bar'}, "
+          + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+          + "{inner: {x: 11, y: 'world'}, z: 21}, "
+          + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+          + "{m: {81d4a032-4632-11f0-9484-409dd8f36eba: 'value3'}}, "
+          + "{l: [1, 2, 3]}, "
+          + "{l: [4, 5]}, "
+          + "{s: {'a', 'b', 'c'}}, "
+          + "{s: {'d', 'e'}}";
+
+  /** Values for untouched UDTs. */
+  private static final String UNTOUCHED_UDT_VALUES =
+      UNTOUCHED_FROZEN_UDT
+          + ", "
+          + UNTOUCHED_NF_UDT
+          + ", "
+          + UNTOUCHED_FROZEN_NESTED_UDT
+          + ", "
+          + UNTOUCHED_NF_NESTED_UDT
+          + ", "
+          + UNTOUCHED_FROZEN_UDT_WITH_MAP
+          + ", "
+          + UNTOUCHED_NF_UDT_WITH_MAP
+          + ", "
+          + UNTOUCHED_FROZEN_UDT_WITH_LIST
+          + ", "
+          + UNTOUCHED_NF_UDT_WITH_LIST
+          + ", "
+          + UNTOUCHED_FROZEN_UDT_WITH_SET
+          + ", "
+          + UNTOUCHED_NF_UDT_WITH_SET;
+
+  // ===================== CQL Update SET Clauses =====================
+
+  /** SET clause for updating all active primitive columns to set 2 values. */
+  private static final String SET_PRIMITIVES_TO_SET2 =
+      "ascii_col = 'ascii_val2', bigint_col = 1234567890124, blob_col = 0xDEADBEEF, "
+          + "boolean_col = false, date_col = '2024-06-11', decimal_col = 98765.43, "
+          + "double_col = 2.71828, duration_col = 2d1h, float_col = 1.41421, "
+          + "inet_col = '127.0.0.2', int_col = 43, smallint_col = 8, text_col = 'text_val2', "
+          + "time_col = '01:02:03.456', timestamp_col = '2024-06-11T01:02:03.456Z', "
+          + "timeuuid_col = 81d4a031-4632-11f0-9484-409dd8f36eba, tinyint_col = 6, "
+          + "uuid_col = 453662fa-db4b-4938-9033-d8523c0a371d, varchar_col = 'varchar_val2', "
+          + "varint_col = 888888888";
+
+  /** SET clause for updating all active non-frozen collections to set 2 values. */
+  private static final String SET_NF_COLLECTIONS_TO_SET2 =
+      "list_col = [40, 50], set_col = {'a', 'b'}, map_col = {3: 'three'}";
+
+  /** SET clause for updating all active frozen collections to set 2 values. */
+  private static final String SET_FROZEN_COLLECTIONS_TO_SET2 =
+      "frozen_list_col = [300, 400], frozen_set_col = {'r', 's'}, "
+          + "frozen_map_col = {20: 'twenty'}, frozen_tuple_col = (2, 'tuple2')";
+
+  /** SET clause for updating all active UDTs to set 2 values. */
+  private static final String SET_UDTS_TO_SET2 =
+      "frozen_udt = {a: 99, b: 'updated'}, "
+          + "nf_udt = {a: 88, b: 'updated_nf'}, "
+          + "frozen_nested_udt = {inner: {x: 50, y: 'updated_inner'}, z: 60}, "
+          + "nf_nested_udt = {inner: {x: 51, y: 'updated_nf_inner'}, z: 61}, "
+          + "frozen_udt_with_map = {m: {81d4a036-4632-11f0-9484-409dd8f36eba: 'newvalue'}}, "
+          + "nf_udt_with_map = {m: {81d4a037-4632-11f0-9484-409dd8f36eba: 'newvalue2'}}, "
+          + "frozen_udt_with_list = {l: [7, 8, 9]}, "
+          + "nf_udt_with_list = {l: [10, 11]}, "
+          + "frozen_udt_with_set = {s: {'x', 'y'}}, "
+          + "nf_udt_with_set = {s: {'z'}}";
+
+  /** SET clause for updating only primitive columns (for single-category update test). */
+  private static final String SET_ONLY_PRIMITIVES =
+      "ascii_col = 'ascii_val2', text_col = 'text_val2', int_col = 43";
+
+  // ===================== Consumer Setup =====================
+
+  /**
    * Builds a KafkaConsumer with the specified before/after mode configuration.
-   *
-   * <p>This helper method encapsulates the common connector setup pattern: creating properties,
-   * setting CDC configuration, registering the connector, and subscribing to the topic.
    *
    * @param connectorName the name of the connector
    * @param tableName the table name to subscribe to
@@ -82,8 +423,6 @@ public abstract class CdcIncludeBeforeAfterBase<K, V> extends ScyllaTypesIT<K, V
     props.put("cdc.output.format", "advanced");
     props.put("cdc.include.before", beforeMode);
     props.put("cdc.include.after", afterMode);
-    // Include PK in all locations for easier test verification.
-    // payload-key is needed for DELETE on partition-key-only tables where before=null.
     props.put(
         "cdc.include.primary-key.placement", "kafka-key,payload-after,payload-before,payload-key");
     KafkaConnectUtils.registerConnector(props, connectorName);
@@ -91,130 +430,1002 @@ public abstract class CdcIncludeBeforeAfterBase<K, V> extends ScyllaTypesIT<K, V
     return consumer;
   }
 
-  /** Returns the name value for INSERT test. Default is "test_<pk>". */
-  protected String insertNameValue(int pk) {
-    return "test_" + pk;
+  // ===================== CQL Helper Methods =====================
+
+  /** Builds complete VALUES clause for INSERT with all columns using set 1 values. */
+  private String buildInsertValuesSet1(int pk) {
+    return pk
+        + ", "
+        + PRIMITIVE_VALUES_SET1
+        + ", "
+        + UNTOUCHED_PRIMITIVE_VALUES
+        + ", "
+        + NF_COLLECTION_VALUES_SET1
+        + ", "
+        + UNTOUCHED_NF_COLLECTION_VALUES
+        + ", "
+        + FROZEN_COLLECTION_VALUES_SET1
+        + ", "
+        + UNTOUCHED_FROZEN_COLLECTION_VALUES
+        + ", "
+        + UDT_VALUES_SET1
+        + ", "
+        + UNTOUCHED_UDT_VALUES;
   }
 
-  /** Returns the initial value for INSERT test. */
-  protected int insertValueValue(int pk) {
-    return 100 + pk;
+  /** Inserts a full row with all columns using set 1 values. */
+  protected void insertFullRow(int pk) {
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + ALL_COLUMNS
+            + ") VALUES ("
+            + buildInsertValuesSet1(pk)
+            + ")");
   }
 
-  /** Returns the name value for DELETE test insert. Default is "delete_<pk>". */
-  protected String deleteNameValue(int pk) {
-    return "delete_" + pk;
+  /** Deletes a row by primary key. */
+  protected void deleteRow(int pk) {
+    session.execute("DELETE FROM " + getSuiteKeyspaceTableName() + " WHERE id = " + pk);
   }
 
-  /** Returns the initial value for DELETE test. */
-  protected int deleteValueValue(int pk) {
-    return 200 + pk;
+  /** Updates all active columns (primitives, collections, UDTs) to set 2 values. */
+  protected void updateAllActiveColumns(int pk) {
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + SET_PRIMITIVES_TO_SET2
+            + ", "
+            + SET_NF_COLLECTIONS_TO_SET2
+            + ", "
+            + SET_FROZEN_COLLECTIONS_TO_SET2
+            + ", "
+            + SET_UDTS_TO_SET2
+            + " WHERE id = "
+            + pk);
   }
 
-  /** Returns the name value before UPDATE test. Default is "before_<pk>". */
-  protected String updateBeforeNameValue(int pk) {
-    return "before_" + pk;
+  /** Updates only a subset of primitive columns (for testing only-updated mode). */
+  protected void updateSomePrimitives(int pk) {
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + SET_ONLY_PRIMITIVES
+            + " WHERE id = "
+            + pk);
   }
 
-  /** Returns the name value after UPDATE test. Default is "after_<pk>". */
-  protected String updateAfterNameValue(int pk) {
-    return "after_" + pk;
-  }
-
-  /** Returns the initial value for UPDATE test (before update). */
-  protected int updateBeforeValueValue(int pk) {
-    return 300 + pk;
-  }
-
-  /** Returns the updated value for multi-column UPDATE test. */
-  protected int updateAfterValueValue(int pk) {
-    return 400 + pk;
-  }
+  // ===================== Test Methods =====================
 
   @Test
   void testInsert() {
     int pk = reservePk();
-    session.execute(
-        "INSERT INTO "
-            + getSuiteKeyspaceTableName()
-            + " (id, name, value) VALUES ("
-            + pk
-            + ", '"
-            + insertNameValue(pk)
-            + "', "
-            + insertValueValue(pk)
-            + ")");
+    insertFullRow(pk);
     waitAndAssert(pk, expectedInsert(pk));
   }
 
   @Test
   void testDelete() {
     int pk = reservePk();
-    session.execute(
-        "INSERT INTO "
-            + getSuiteKeyspaceTableName()
-            + " (id, name, value) VALUES ("
-            + pk
-            + ", '"
-            + deleteNameValue(pk)
-            + "', "
-            + deleteValueValue(pk)
-            + ")");
-    session.execute("DELETE FROM " + getSuiteKeyspaceTableName() + " WHERE id = " + pk);
+    insertFullRow(pk);
+    deleteRow(pk);
     waitAndAssert(pk, expectedDelete(pk));
   }
 
-  /** Tests UPDATE operation that modifies only a single column (name). */
+  /** Tests UPDATE operation that modifies only a few columns (for testing only-updated mode). */
   @Test
   void testUpdateSingleColumn() {
     int pk = reservePk();
-    // Insert initial row with both name and value
-    session.execute(
-        "INSERT INTO "
-            + getSuiteKeyspaceTableName()
-            + " (id, name, value) VALUES ("
-            + pk
-            + ", '"
-            + updateBeforeNameValue(pk)
-            + "', "
-            + updateBeforeValueValue(pk)
-            + ")");
-    // Update only the name column (value stays unchanged)
-    session.execute(
-        "UPDATE "
-            + getSuiteKeyspaceTableName()
-            + " SET name = '"
-            + updateAfterNameValue(pk)
-            + "' WHERE id = "
-            + pk);
+    insertFullRow(pk);
+    updateSomePrimitives(pk);
     waitAndAssert(pk, expectedUpdate(pk));
   }
 
-  /** Tests UPDATE operation that modifies multiple columns (name and value). */
+  /** Tests UPDATE operation that modifies all active columns. */
   @Test
   void testUpdateMultiColumn() {
     int pk = reservePk();
-    // Insert initial row with both name and value
-    session.execute(
-        "INSERT INTO "
-            + getSuiteKeyspaceTableName()
-            + " (id, name, value) VALUES ("
-            + pk
-            + ", '"
-            + updateBeforeNameValue(pk)
-            + "', "
-            + updateBeforeValueValue(pk)
-            + ")");
-    // Update both name and value columns
-    session.execute(
-        "UPDATE "
-            + getSuiteKeyspaceTableName()
-            + " SET name = '"
-            + updateAfterNameValue(pk)
-            + "', value = "
-            + updateAfterValueValue(pk)
-            + " WHERE id = "
-            + pk);
+    insertFullRow(pk);
+    updateAllActiveColumns(pk);
     waitAndAssert(pk, expectedUpdateMultiColumn(pk));
+  }
+
+  // ===================== Expected JSON Value Constants =====================
+  // These are the expected JSON representations of values in Kafka records.
+  // Note: JSON representations may differ from CQL values (e.g., blob is base64 encoded).
+
+  // --- Set 1 Values (Initial/Before UPDATE) ---
+  static final String JSON_ASCII_SET1 = "ascii_val";
+  static final long JSON_BIGINT_SET1 = 1234567890123L;
+  static final String JSON_BLOB_SET1 = "yv66vg=="; // base64 of 0xCAFEBABE
+  static final boolean JSON_BOOLEAN_SET1 = true;
+  static final int JSON_DATE_SET1 = 19884; // days since epoch for 2024-06-10
+  static final String JSON_DECIMAL_SET1 = "12345.67";
+  static final double JSON_DOUBLE_SET1 = 3.14159;
+  static final String JSON_DURATION_SET1 = "1d12h30m";
+  static final double JSON_FLOAT_SET1 = 2.71828;
+  static final String JSON_INET_SET1 = "127.0.0.1";
+  static final int JSON_INT_SET1 = 42;
+  static final int JSON_SMALLINT_SET1 = 7;
+  static final String JSON_TEXT_SET1 = "text_val";
+  static final long JSON_TIME_SET1 = 45296789000000L; // nanoseconds for 12:34:56.789
+  static final long JSON_TIMESTAMP_SET1 = 1718022896789L; // millis for 2024-06-10T12:34:56.789Z
+  static final String JSON_TIMEUUID_SET1 = "81d4a030-4632-11f0-9484-409dd8f36eba";
+  static final int JSON_TINYINT_SET1 = 5;
+  static final String JSON_UUID_SET1 = "453662fa-db4b-4938-9033-d8523c0a371c";
+  static final String JSON_VARCHAR_SET1 = "varchar_val";
+  static final String JSON_VARINT_SET1 = "999999999";
+
+  // --- Set 2 Values (After UPDATE) ---
+  static final String JSON_ASCII_SET2 = "ascii_val2";
+  static final long JSON_BIGINT_SET2 = 1234567890124L;
+  static final String JSON_BLOB_SET2 = "3q2+7w=="; // base64 of 0xDEADBEEF
+  static final boolean JSON_BOOLEAN_SET2 = false;
+  static final int JSON_DATE_SET2 = 19885; // days since epoch for 2024-06-11
+  static final String JSON_DECIMAL_SET2 = "98765.43";
+  static final double JSON_DOUBLE_SET2 = 2.71828;
+  static final String JSON_DURATION_SET2 = "2d1h";
+  static final double JSON_FLOAT_SET2 = 1.41421;
+  static final String JSON_INET_SET2 = "127.0.0.2";
+  static final int JSON_INT_SET2 = 43;
+  static final int JSON_SMALLINT_SET2 = 8;
+  static final String JSON_TEXT_SET2 = "text_val2";
+  static final long JSON_TIME_SET2 = 3723456000000L; // nanoseconds for 01:02:03.456
+  static final long JSON_TIMESTAMP_SET2 = 1718067723456L; // millis for 2024-06-11T01:02:03.456Z
+  static final String JSON_TIMEUUID_SET2 = "81d4a031-4632-11f0-9484-409dd8f36eba";
+  static final int JSON_TINYINT_SET2 = 6;
+  static final String JSON_UUID_SET2 = "453662fa-db4b-4938-9033-d8523c0a371d";
+  static final String JSON_VARCHAR_SET2 = "varchar_val2";
+  static final String JSON_VARINT_SET2 = "888888888";
+
+  // --- Untouched Values (JSON representations) ---
+  static final String JSON_UNTOUCHED_ASCII = UNTOUCHED_ASCII;
+  static final long JSON_UNTOUCHED_BIGINT = UNTOUCHED_BIGINT;
+  static final String JSON_UNTOUCHED_BLOB = "3q3K/g=="; // base64 of 0xDEADCAFE
+  static final boolean JSON_UNTOUCHED_BOOLEAN = UNTOUCHED_BOOLEAN;
+  static final int JSON_UNTOUCHED_DATE = 18262; // days since epoch for 2020-01-01
+  static final String JSON_UNTOUCHED_DECIMAL = UNTOUCHED_DECIMAL;
+  static final double JSON_UNTOUCHED_DOUBLE = UNTOUCHED_DOUBLE;
+  static final String JSON_UNTOUCHED_DURATION = UNTOUCHED_DURATION;
+  static final double JSON_UNTOUCHED_FLOAT = 9.99; // JSON uses the raw float value
+  static final String JSON_UNTOUCHED_INET = UNTOUCHED_INET;
+  static final int JSON_UNTOUCHED_INT = UNTOUCHED_INT;
+  static final int JSON_UNTOUCHED_SMALLINT = UNTOUCHED_SMALLINT;
+  static final String JSON_UNTOUCHED_TEXT = UNTOUCHED_TEXT;
+  static final long JSON_UNTOUCHED_TIME = 32949999000000L; // nanoseconds for 09:09:09.999
+  static final long JSON_UNTOUCHED_TIMESTAMP =
+      1577869749999L; // millis for 2020-01-01T09:09:09.999Z
+  static final String JSON_UNTOUCHED_TIMEUUID = UNTOUCHED_TIMEUUID;
+  static final int JSON_UNTOUCHED_TINYINT = UNTOUCHED_TINYINT;
+  static final String JSON_UNTOUCHED_UUID = UNTOUCHED_UUID;
+  static final String JSON_UNTOUCHED_VARCHAR = UNTOUCHED_VARCHAR;
+  static final String JSON_UNTOUCHED_VARINT = UNTOUCHED_VARINT;
+
+  // ===================== JSON Builder Helpers =====================
+
+  /**
+   * Builds the expected JSON for all primitive columns with Set 1 values.
+   *
+   * @param pk the primary key value
+   * @return JSON fragment for all primitives (active + untouched) with Set 1 values
+   */
+  protected static String jsonPrimitivesSet1(int pk) {
+    return """
+        "id": %d,
+        "ascii_col": "%s",
+        "bigint_col": %d,
+        "blob_col": "%s",
+        "boolean_col": %s,
+        "date_col": %d,
+        "decimal_col": "%s",
+        "double_col": %s,
+        "duration_col": "%s",
+        "float_col": %s,
+        "inet_col": "%s",
+        "int_col": %d,
+        "smallint_col": %d,
+        "text_col": "%s",
+        "time_col": %d,
+        "timestamp_col": %d,
+        "timeuuid_col": "%s",
+        "tinyint_col": %d,
+        "uuid_col": "%s",
+        "varchar_col": "%s",
+        "varint_col": "%s\""""
+        .formatted(
+            pk,
+            JSON_ASCII_SET1,
+            JSON_BIGINT_SET1,
+            JSON_BLOB_SET1,
+            JSON_BOOLEAN_SET1,
+            JSON_DATE_SET1,
+            JSON_DECIMAL_SET1,
+            JSON_DOUBLE_SET1,
+            JSON_DURATION_SET1,
+            JSON_FLOAT_SET1,
+            JSON_INET_SET1,
+            JSON_INT_SET1,
+            JSON_SMALLINT_SET1,
+            JSON_TEXT_SET1,
+            JSON_TIME_SET1,
+            JSON_TIMESTAMP_SET1,
+            JSON_TIMEUUID_SET1,
+            JSON_TINYINT_SET1,
+            JSON_UUID_SET1,
+            JSON_VARCHAR_SET1,
+            JSON_VARINT_SET1);
+  }
+
+  /**
+   * Builds the expected JSON for all primitive columns with Set 2 values.
+   *
+   * @param pk the primary key value
+   * @return JSON fragment for all primitives (active only) with Set 2 values
+   */
+  protected static String jsonPrimitivesSet2(int pk) {
+    return """
+        "id": %d,
+        "ascii_col": "%s",
+        "bigint_col": %d,
+        "blob_col": "%s",
+        "boolean_col": %s,
+        "date_col": %d,
+        "decimal_col": "%s",
+        "double_col": %s,
+        "duration_col": "%s",
+        "float_col": %s,
+        "inet_col": "%s",
+        "int_col": %d,
+        "smallint_col": %d,
+        "text_col": "%s",
+        "time_col": %d,
+        "timestamp_col": %d,
+        "timeuuid_col": "%s",
+        "tinyint_col": %d,
+        "uuid_col": "%s",
+        "varchar_col": "%s",
+        "varint_col": "%s\""""
+        .formatted(
+            pk,
+            JSON_ASCII_SET2,
+            JSON_BIGINT_SET2,
+            JSON_BLOB_SET2,
+            JSON_BOOLEAN_SET2,
+            JSON_DATE_SET2,
+            JSON_DECIMAL_SET2,
+            JSON_DOUBLE_SET2,
+            JSON_DURATION_SET2,
+            JSON_FLOAT_SET2,
+            JSON_INET_SET2,
+            JSON_INT_SET2,
+            JSON_SMALLINT_SET2,
+            JSON_TEXT_SET2,
+            JSON_TIME_SET2,
+            JSON_TIMESTAMP_SET2,
+            JSON_TIMEUUID_SET2,
+            JSON_TINYINT_SET2,
+            JSON_UUID_SET2,
+            JSON_VARCHAR_SET2,
+            JSON_VARINT_SET2);
+  }
+
+  /** Builds JSON for untouched primitive columns. */
+  protected static String jsonUntouchedPrimitives() {
+    return """
+        "untouched_ascii": "%s",
+        "untouched_bigint": %d,
+        "untouched_blob": "%s",
+        "untouched_boolean": %s,
+        "untouched_date": %d,
+        "untouched_decimal": "%s",
+        "untouched_double": %s,
+        "untouched_duration": "%s",
+        "untouched_float": %s,
+        "untouched_inet": "%s",
+        "untouched_int": %d,
+        "untouched_smallint": %d,
+        "untouched_text": "%s",
+        "untouched_time": %d,
+        "untouched_timestamp": %d,
+        "untouched_timeuuid": "%s",
+        "untouched_tinyint": %d,
+        "untouched_uuid": "%s",
+        "untouched_varchar": "%s",
+        "untouched_varint": "%s\""""
+        .formatted(
+            JSON_UNTOUCHED_ASCII,
+            JSON_UNTOUCHED_BIGINT,
+            JSON_UNTOUCHED_BLOB,
+            JSON_UNTOUCHED_BOOLEAN,
+            JSON_UNTOUCHED_DATE,
+            JSON_UNTOUCHED_DECIMAL,
+            JSON_UNTOUCHED_DOUBLE,
+            JSON_UNTOUCHED_DURATION,
+            JSON_UNTOUCHED_FLOAT,
+            JSON_UNTOUCHED_INET,
+            JSON_UNTOUCHED_INT,
+            JSON_UNTOUCHED_SMALLINT,
+            JSON_UNTOUCHED_TEXT,
+            JSON_UNTOUCHED_TIME,
+            JSON_UNTOUCHED_TIMESTAMP,
+            JSON_UNTOUCHED_TIMEUUID,
+            JSON_UNTOUCHED_TINYINT,
+            JSON_UNTOUCHED_UUID,
+            JSON_UNTOUCHED_VARCHAR,
+            JSON_UNTOUCHED_VARINT);
+  }
+
+  /** Builds JSON for non-frozen collections with Set 1 values. */
+  protected static String jsonNfCollectionsSet1() {
+    // Note: Maps are serialized as arrays of {"key": ..., "value": ...} objects
+    return """
+        "list_col": [10, 20, 30],
+        "set_col": ["x", "y", "z"],
+        "map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}]""";
+  }
+
+  /** Builds JSON for non-frozen collections with Set 2 values. */
+  protected static String jsonNfCollectionsSet2() {
+    return """
+        "list_col": [40, 50],
+        "set_col": ["a", "b"],
+        "map_col": [{"key": 3, "value": "three"}]""";
+  }
+
+  /** Builds JSON for untouched non-frozen collections. */
+  protected static String jsonUntouchedNfCollections() {
+    return """
+        "untouched_list": [999, 998, 997],
+        "untouched_set": ["untouched_a", "untouched_b"],
+        "untouched_map": [{"key": 999, "value": "untouched_val"}]""";
+  }
+
+  /** Builds JSON for frozen collections with Set 1 values. */
+  protected static String jsonFrozenCollectionsSet1() {
+    // Note: Maps are serialized as arrays of {"key": ..., "value": ...} objects
+    // Note: Tuples are serialized as objects with "field_N" keys for Avro compatibility
+    return """
+        "frozen_list_col": [100, 200],
+        "frozen_set_col": ["p", "q"],
+        "frozen_map_col": [{"key": 10, "value": "ten"}],
+        "frozen_tuple_col": {"field_0": 1, "field_1": "tuple1"}""";
+  }
+
+  /** Builds JSON for frozen collections with Set 2 values. */
+  protected static String jsonFrozenCollectionsSet2() {
+    return """
+        "frozen_list_col": [300, 400],
+        "frozen_set_col": ["r", "s"],
+        "frozen_map_col": [{"key": 20, "value": "twenty"}],
+        "frozen_tuple_col": {"field_0": 2, "field_1": "tuple2"}""";
+  }
+
+  /** Builds JSON for untouched frozen collections. */
+  protected static String jsonUntouchedFrozenCollections() {
+    return """
+        "untouched_frozen_list": [999, 998],
+        "untouched_frozen_set": ["untouched_x", "untouched_y"],
+        "untouched_frozen_map": [{"key": 999, "value": "untouched_frozen"}],
+        "untouched_frozen_tuple": {"field_0": 999, "field_1": "untouched_tuple"}""";
+  }
+
+  /** Builds JSON for UDTs with Set 1 values. */
+  protected static String jsonUdtsSet1() {
+    // Note: Maps inside UDTs are also serialized as arrays of {"key": ..., "value": ...} objects
+    return """
+        "frozen_udt": {"a": 42, "b": "foo"},
+        "nf_udt": {"a": 7, "b": "bar"},
+        "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+        "nf_nested_udt": {"inner": {"x": 11, "y": "world"}, "z": 21},
+        "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+        "nf_udt_with_map": {"m": [{"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+        "frozen_udt_with_list": {"l": [1, 2, 3]},
+        "nf_udt_with_list": {"l": [4, 5]},
+        "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+        "nf_udt_with_set": {"s": ["d", "e"]}""";
+  }
+
+  /** Builds JSON for UDTs with Set 2 values. */
+  protected static String jsonUdtsSet2() {
+    return """
+        "frozen_udt": {"a": 99, "b": "updated"},
+        "nf_udt": {"a": 88, "b": "updated_nf"},
+        "frozen_nested_udt": {"inner": {"x": 50, "y": "updated_inner"}, "z": 60},
+        "nf_nested_udt": {"inner": {"x": 51, "y": "updated_nf_inner"}, "z": 61},
+        "frozen_udt_with_map": {"m": [{"key": "81d4a036-4632-11f0-9484-409dd8f36eba", "value": "newvalue"}]},
+        "nf_udt_with_map": {"m": [{"key": "81d4a037-4632-11f0-9484-409dd8f36eba", "value": "newvalue2"}]},
+        "frozen_udt_with_list": {"l": [7, 8, 9]},
+        "nf_udt_with_list": {"l": [10, 11]},
+        "frozen_udt_with_set": {"s": ["x", "y"]},
+        "nf_udt_with_set": {"s": ["z"]}""";
+  }
+
+  /** Builds JSON for untouched UDTs. */
+  protected static String jsonUntouchedUdts() {
+    return """
+        "untouched_frozen_udt": {"a": 999, "b": "untouched_udt"},
+        "untouched_nf_udt": {"a": 998, "b": "untouched_nf_udt"},
+        "untouched_frozen_nested_udt": {"inner": {"x": 999, "y": "untouched_inner"}, "z": 999},
+        "untouched_nf_nested_udt": {"inner": {"x": 998, "y": "untouched_nf_inner"}, "z": 998},
+        "untouched_frozen_udt_with_map": {"m": [{"key": "81d4a034-4632-11f0-9484-409dd8f36eba", "value": "untouched_value"}]},
+        "untouched_nf_udt_with_map": {"m": [{"key": "81d4a035-4632-11f0-9484-409dd8f36eba", "value": "untouched_nf_value"}]},
+        "untouched_frozen_udt_with_list": {"l": [999, 998]},
+        "untouched_nf_udt_with_list": {"l": [997, 996]},
+        "untouched_frozen_udt_with_set": {"s": ["untouched_set_a", "untouched_set_b"]},
+        "untouched_nf_udt_with_set": {"s": ["untouched_nf_set_a", "untouched_nf_set_b"]}""";
+  }
+
+  // ===================== Full Image Builders (for mode=full) =====================
+
+  /**
+   * Builds a complete JSON object with all columns using Set 1 values. Used for "full" mode after
+   * INSERT or before UPDATE.
+   *
+   * @param pk the primary key value
+   * @return complete JSON object string with all columns
+   */
+  protected static String jsonFullImageSet1(int pk) {
+    return "{\n"
+        + jsonPrimitivesSet1(pk)
+        + ",\n"
+        + jsonUntouchedPrimitives()
+        + ",\n"
+        + jsonNfCollectionsSet1()
+        + ",\n"
+        + jsonUntouchedNfCollections()
+        + ",\n"
+        + jsonFrozenCollectionsSet1()
+        + ",\n"
+        + jsonUntouchedFrozenCollections()
+        + ",\n"
+        + jsonUdtsSet1()
+        + ",\n"
+        + jsonUntouchedUdts()
+        + "\n}";
+  }
+
+  /**
+   * Builds a complete JSON object with active columns using Set 2 values and untouched columns
+   * unchanged. Used for "full" mode after UPDATE.
+   *
+   * @param pk the primary key value
+   * @return complete JSON object string with all columns (active=Set2, untouched=unchanged)
+   */
+  protected static String jsonFullImageSet2(int pk) {
+    return "{\n"
+        + jsonPrimitivesSet2(pk)
+        + ",\n"
+        + jsonUntouchedPrimitives()
+        + ",\n"
+        + jsonNfCollectionsSet2()
+        + ",\n"
+        + jsonUntouchedNfCollections()
+        + ",\n"
+        + jsonFrozenCollectionsSet2()
+        + ",\n"
+        + jsonUntouchedFrozenCollections()
+        + ",\n"
+        + jsonUdtsSet2()
+        + ",\n"
+        + jsonUntouchedUdts()
+        + "\n}";
+  }
+
+  // ===================== Partial Update Full Image Builder =====================
+
+  /**
+   * Builds JSON for primitive columns after a partial update (only ascii_col, text_col, int_col
+   * changed to Set 2, all other primitives remain Set 1).
+   *
+   * @param pk the primary key value
+   * @return JSON fragment for primitives after partial update
+   */
+  protected static String jsonPrimitivesPartialUpdate(int pk) {
+    return """
+        "id": %d,
+        "ascii_col": "%s",
+        "bigint_col": %d,
+        "blob_col": "%s",
+        "boolean_col": %s,
+        "date_col": %d,
+        "decimal_col": "%s",
+        "double_col": %s,
+        "duration_col": "%s",
+        "float_col": %s,
+        "inet_col": "%s",
+        "int_col": %d,
+        "smallint_col": %d,
+        "text_col": "%s",
+        "time_col": %d,
+        "timestamp_col": %d,
+        "timeuuid_col": "%s",
+        "tinyint_col": %d,
+        "uuid_col": "%s",
+        "varchar_col": "%s",
+        "varint_col": "%s\""""
+        .formatted(
+            pk,
+            JSON_ASCII_SET2, // changed
+            JSON_BIGINT_SET1, // unchanged
+            JSON_BLOB_SET1, // unchanged
+            JSON_BOOLEAN_SET1, // unchanged
+            JSON_DATE_SET1, // unchanged
+            JSON_DECIMAL_SET1, // unchanged
+            JSON_DOUBLE_SET1, // unchanged
+            JSON_DURATION_SET1, // unchanged
+            JSON_FLOAT_SET1, // unchanged
+            JSON_INET_SET1, // unchanged
+            JSON_INT_SET2, // changed
+            JSON_SMALLINT_SET1, // unchanged
+            JSON_TEXT_SET2, // changed
+            JSON_TIME_SET1, // unchanged
+            JSON_TIMESTAMP_SET1, // unchanged
+            JSON_TIMEUUID_SET1, // unchanged
+            JSON_TINYINT_SET1, // unchanged
+            JSON_UUID_SET1, // unchanged
+            JSON_VARCHAR_SET1, // unchanged
+            JSON_VARINT_SET1); // unchanged
+  }
+
+  /**
+   * Builds a complete JSON object for the full image after a partial update. Only ascii_col,
+   * text_col, and int_col are changed to Set 2 values; all other columns retain their original
+   * values.
+   *
+   * @param pk the primary key value
+   * @return complete JSON object string with partial update applied
+   */
+  protected static String jsonFullImagePartialUpdate(int pk) {
+    return "{\n"
+        + jsonPrimitivesPartialUpdate(pk)
+        + ",\n"
+        + jsonUntouchedPrimitives()
+        + ",\n"
+        + jsonNfCollectionsSet1() // collections unchanged
+        + ",\n"
+        + jsonUntouchedNfCollections()
+        + ",\n"
+        + jsonFrozenCollectionsSet1() // frozen collections unchanged
+        + ",\n"
+        + jsonUntouchedFrozenCollections()
+        + ",\n"
+        + jsonUdtsSet1() // UDTs unchanged
+        + ",\n"
+        + jsonUntouchedUdts()
+        + "\n}";
+  }
+
+  // ===================== Only-Updated Image Builders (for mode=only-updated) =====================
+  // Note: "only-updated" mode includes ALL columns in the JSON schema, but non-updated columns
+  // are set to null. Only updated columns have actual values.
+
+  /**
+   * Builds JSON with all columns, where only the columns modified in updateSomePrimitives() have
+   * values (Set 1), and all other columns are null. Used for "only-updated" mode before partial
+   * UPDATE.
+   *
+   * @param pk the primary key value
+   * @return JSON object with all columns (updated=Set1 values, non-updated=null)
+   */
+  protected static String jsonOnlyUpdatedPrimitivesBefore(int pk) {
+    return """
+        {
+          "ascii_col": "%s",
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "frozen_list_col": null,
+          "frozen_map_col": null,
+          "frozen_nested_udt": null,
+          "frozen_set_col": null,
+          "frozen_tuple_col": null,
+          "frozen_udt": null,
+          "frozen_udt_with_list": null,
+          "frozen_udt_with_map": null,
+          "frozen_udt_with_set": null,
+          "id": %d,
+          "inet_col": null,
+          "int_col": %d,
+          "list_col": null,
+          "map_col": null,
+          "nf_nested_udt": null,
+          "nf_udt": null,
+          "nf_udt_with_list": null,
+          "nf_udt_with_map": null,
+          "nf_udt_with_set": null,
+          "set_col": null,
+          "smallint_col": null,
+          "text_col": "%s",
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "untouched_ascii": null,
+          "untouched_bigint": null,
+          "untouched_blob": null,
+          "untouched_boolean": null,
+          "untouched_date": null,
+          "untouched_decimal": null,
+          "untouched_double": null,
+          "untouched_duration": null,
+          "untouched_float": null,
+          "untouched_frozen_list": null,
+          "untouched_frozen_map": null,
+          "untouched_frozen_nested_udt": null,
+          "untouched_frozen_set": null,
+          "untouched_frozen_tuple": null,
+          "untouched_frozen_udt": null,
+          "untouched_frozen_udt_with_list": null,
+          "untouched_frozen_udt_with_map": null,
+          "untouched_frozen_udt_with_set": null,
+          "untouched_inet": null,
+          "untouched_int": null,
+          "untouched_list": null,
+          "untouched_map": null,
+          "untouched_nf_nested_udt": null,
+          "untouched_nf_udt": null,
+          "untouched_nf_udt_with_list": null,
+          "untouched_nf_udt_with_map": null,
+          "untouched_nf_udt_with_set": null,
+          "untouched_set": null,
+          "untouched_smallint": null,
+          "untouched_text": null,
+          "untouched_time": null,
+          "untouched_timestamp": null,
+          "untouched_timeuuid": null,
+          "untouched_tinyint": null,
+          "untouched_uuid": null,
+          "untouched_varchar": null,
+          "untouched_varint": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null
+        }"""
+        .formatted(JSON_ASCII_SET1, pk, JSON_INT_SET1, JSON_TEXT_SET1);
+  }
+
+  /**
+   * Builds JSON with all columns, where only the columns modified in updateSomePrimitives() have
+   * values (Set 2), and all other columns are null. Used for "only-updated" mode after partial
+   * UPDATE.
+   *
+   * @param pk the primary key value
+   * @return JSON object with all columns (updated=Set2 values, non-updated=null)
+   */
+  protected static String jsonOnlyUpdatedPrimitivesAfter(int pk) {
+    return """
+        {
+          "ascii_col": "%s",
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "frozen_list_col": null,
+          "frozen_map_col": null,
+          "frozen_nested_udt": null,
+          "frozen_set_col": null,
+          "frozen_tuple_col": null,
+          "frozen_udt": null,
+          "frozen_udt_with_list": null,
+          "frozen_udt_with_map": null,
+          "frozen_udt_with_set": null,
+          "id": %d,
+          "inet_col": null,
+          "int_col": %d,
+          "list_col": null,
+          "map_col": null,
+          "nf_nested_udt": null,
+          "nf_udt": null,
+          "nf_udt_with_list": null,
+          "nf_udt_with_map": null,
+          "nf_udt_with_set": null,
+          "set_col": null,
+          "smallint_col": null,
+          "text_col": "%s",
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "untouched_ascii": null,
+          "untouched_bigint": null,
+          "untouched_blob": null,
+          "untouched_boolean": null,
+          "untouched_date": null,
+          "untouched_decimal": null,
+          "untouched_double": null,
+          "untouched_duration": null,
+          "untouched_float": null,
+          "untouched_frozen_list": null,
+          "untouched_frozen_map": null,
+          "untouched_frozen_nested_udt": null,
+          "untouched_frozen_set": null,
+          "untouched_frozen_tuple": null,
+          "untouched_frozen_udt": null,
+          "untouched_frozen_udt_with_list": null,
+          "untouched_frozen_udt_with_map": null,
+          "untouched_frozen_udt_with_set": null,
+          "untouched_inet": null,
+          "untouched_int": null,
+          "untouched_list": null,
+          "untouched_map": null,
+          "untouched_nf_nested_udt": null,
+          "untouched_nf_udt": null,
+          "untouched_nf_udt_with_list": null,
+          "untouched_nf_udt_with_map": null,
+          "untouched_nf_udt_with_set": null,
+          "untouched_set": null,
+          "untouched_smallint": null,
+          "untouched_text": null,
+          "untouched_time": null,
+          "untouched_timestamp": null,
+          "untouched_timeuuid": null,
+          "untouched_tinyint": null,
+          "untouched_uuid": null,
+          "untouched_varchar": null,
+          "untouched_varint": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null
+        }"""
+        .formatted(JSON_ASCII_SET2, pk, JSON_INT_SET2, JSON_TEXT_SET2);
+  }
+
+  /** Builds JSON for null untouched primitive columns (used in only-updated mode). */
+  protected static String jsonNullUntouchedPrimitives() {
+    return """
+        "untouched_ascii": null,
+        "untouched_bigint": null,
+        "untouched_blob": null,
+        "untouched_boolean": null,
+        "untouched_date": null,
+        "untouched_decimal": null,
+        "untouched_double": null,
+        "untouched_duration": null,
+        "untouched_float": null,
+        "untouched_inet": null,
+        "untouched_int": null,
+        "untouched_smallint": null,
+        "untouched_text": null,
+        "untouched_time": null,
+        "untouched_timestamp": null,
+        "untouched_timeuuid": null,
+        "untouched_tinyint": null,
+        "untouched_uuid": null,
+        "untouched_varchar": null,
+        "untouched_varint": null""";
+  }
+
+  /** Builds JSON for null untouched non-frozen collections (used in only-updated mode). */
+  protected static String jsonNullUntouchedNfCollections() {
+    return """
+        "untouched_list": null,
+        "untouched_set": null,
+        "untouched_map": null""";
+  }
+
+  /** Builds JSON for null untouched frozen collections (used in only-updated mode). */
+  protected static String jsonNullUntouchedFrozenCollections() {
+    return """
+        "untouched_frozen_list": null,
+        "untouched_frozen_set": null,
+        "untouched_frozen_map": null,
+        "untouched_frozen_tuple": null""";
+  }
+
+  /** Builds JSON for null untouched UDTs (used in only-updated mode). */
+  protected static String jsonNullUntouchedUdts() {
+    return """
+        "untouched_frozen_udt": null,
+        "untouched_nf_udt": null,
+        "untouched_frozen_nested_udt": null,
+        "untouched_nf_nested_udt": null,
+        "untouched_frozen_udt_with_map": null,
+        "untouched_nf_udt_with_map": null,
+        "untouched_frozen_udt_with_list": null,
+        "untouched_nf_udt_with_list": null,
+        "untouched_frozen_udt_with_set": null,
+        "untouched_nf_udt_with_set": null""";
+  }
+
+  /**
+   * Builds JSON with all active columns (modified in updateAllActiveColumns) with Set 1 values, and
+   * all untouched columns set to null. Used for "only-updated" mode before full UPDATE.
+   *
+   * @param pk the primary key value
+   * @return JSON object with all columns (active=Set1 values, untouched=null)
+   */
+  protected static String jsonOnlyUpdatedAllActiveBefore(int pk) {
+    return "{\n"
+        + jsonPrimitivesSet1(pk)
+        + ",\n"
+        + jsonNullUntouchedPrimitives()
+        + ",\n"
+        + jsonNfCollectionsSet1()
+        + ",\n"
+        + jsonNullUntouchedNfCollections()
+        + ",\n"
+        + jsonFrozenCollectionsSet1()
+        + ",\n"
+        + jsonNullUntouchedFrozenCollections()
+        + ",\n"
+        + jsonUdtsSet1()
+        + ",\n"
+        + jsonNullUntouchedUdts()
+        + "\n}";
+  }
+
+  /**
+   * Builds JSON with all active columns (modified in updateAllActiveColumns) with Set 2 values, and
+   * all untouched columns set to null. Used for "only-updated" mode after full UPDATE.
+   *
+   * @param pk the primary key value
+   * @return JSON object with all columns (active=Set2 values, untouched=null)
+   */
+  protected static String jsonOnlyUpdatedAllActiveAfter(int pk) {
+    return "{\n"
+        + jsonPrimitivesSet2(pk)
+        + ",\n"
+        + jsonNullUntouchedPrimitives()
+        + ",\n"
+        + jsonNfCollectionsSet2()
+        + ",\n"
+        + jsonNullUntouchedNfCollections()
+        + ",\n"
+        + jsonFrozenCollectionsSet2()
+        + ",\n"
+        + jsonNullUntouchedFrozenCollections()
+        + ",\n"
+        + jsonUdtsSet2()
+        + ",\n"
+        + jsonNullUntouchedUdts()
+        + "\n}";
+  }
+
+  // ===================== Key JSON Builder =====================
+
+  /**
+   * Builds the expected JSON for the key field.
+   *
+   * @param pk the primary key value
+   * @return JSON object for the key
+   */
+  protected static String jsonKey(int pk) {
+    return "{\"id\": %d}".formatted(pk);
+  }
+
+  // ===================== Complete Record Builders =====================
+
+  /**
+   * Builds a complete expected Kafka record JSON for INSERT operation.
+   *
+   * @param pk the primary key value
+   * @param beforeMode the cdc.include.before mode (none, full, only-updated)
+   * @param afterMode the cdc.include.after mode (none, full, only-updated)
+   * @param source the expected source JSON (use expectedSource())
+   * @return complete JSON record string
+   */
+  protected static String buildInsertRecord(
+      int pk, String beforeMode, String afterMode, String source) {
+    String before = "null"; // INSERT always has null before
+    String after;
+    switch (afterMode) {
+      case "none":
+        after = "null";
+        break;
+      case "only-updated":
+      case "full":
+        // For INSERT, all columns are "updated" so both modes include full image
+        after = jsonFullImageSet1(pk);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown afterMode: " + afterMode);
+    }
+    return buildRecord(pk, before, after, "c", source);
+  }
+
+  /**
+   * Builds a complete expected Kafka record JSON for DELETE operation.
+   *
+   * @param pk the primary key value
+   * @param beforeMode the cdc.include.before mode (none, full, only-updated)
+   * @param afterMode the cdc.include.after mode (none, full, only-updated)
+   * @param source the expected source JSON (use expectedSource())
+   * @return complete JSON record string
+   */
+  protected static String buildDeleteRecord(
+      int pk, String beforeMode, String afterMode, String source) {
+    // Note: For partition-key-only tables, Scylla sends PARTITION_DELETE which has no preimage
+    String before = "null"; // Partition delete has no preimage
+    String after = "null"; // DELETE always has null after
+    return buildRecord(pk, before, after, "d", source);
+  }
+
+  /**
+   * Builds a complete expected Kafka record JSON for UPDATE operation (partial update).
+   *
+   * @param pk the primary key value
+   * @param beforeMode the cdc.include.before mode (none, full, only-updated)
+   * @param afterMode the cdc.include.after mode (none, full, only-updated)
+   * @param source the expected source JSON (use expectedSource())
+   * @return complete JSON record string
+   */
+  protected static String buildUpdateRecord(
+      int pk, String beforeMode, String afterMode, String source) {
+    String before = buildBeforeForUpdate(pk, beforeMode, false);
+    String after = buildAfterForUpdate(pk, afterMode, false);
+    return buildRecord(pk, before, after, "u", source);
+  }
+
+  /**
+   * Builds a complete expected Kafka record JSON for UPDATE operation (full update).
+   *
+   * @param pk the primary key value
+   * @param beforeMode the cdc.include.before mode (none, full, only-updated)
+   * @param afterMode the cdc.include.after mode (none, full, only-updated)
+   * @param source the expected source JSON (use expectedSource())
+   * @return complete JSON record string
+   */
+  protected static String buildUpdateMultiColumnRecord(
+      int pk, String beforeMode, String afterMode, String source) {
+    String before = buildBeforeForUpdate(pk, beforeMode, true);
+    String after = buildAfterForUpdate(pk, afterMode, true);
+    return buildRecord(pk, before, after, "u", source);
+  }
+
+  /** Helper to build before value based on mode. */
+  private static String buildBeforeForUpdate(int pk, String beforeMode, boolean fullUpdate) {
+    switch (beforeMode) {
+      case "none":
+        return "null";
+      case "only-updated":
+        return fullUpdate
+            ? jsonOnlyUpdatedAllActiveBefore(pk)
+            : jsonOnlyUpdatedPrimitivesBefore(pk);
+      case "full":
+        return jsonFullImageSet1(pk);
+      default:
+        throw new IllegalArgumentException("Unknown beforeMode: " + beforeMode);
+    }
+  }
+
+  /** Helper to build after value based on mode. */
+  private static String buildAfterForUpdate(int pk, String afterMode, boolean fullUpdate) {
+    switch (afterMode) {
+      case "none":
+        return "null";
+      case "only-updated":
+        return fullUpdate ? jsonOnlyUpdatedAllActiveAfter(pk) : jsonOnlyUpdatedPrimitivesAfter(pk);
+      case "full":
+        // For full mode, partial update only changes some columns
+        // Full update changes all active columns
+        return fullUpdate ? jsonFullImageSet2(pk) : jsonFullImagePartialUpdate(pk);
+      default:
+        throw new IllegalArgumentException("Unknown afterMode: " + afterMode);
+    }
+  }
+
+  /** Helper to build a complete record JSON. */
+  private static String buildRecord(int pk, String before, String after, String op, String source) {
+    return """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "%s",
+          "source": %s
+        }"""
+        .formatted(before, after, jsonKey(pk), op, source);
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeAfterOnlyUpdatedIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeAfterOnlyUpdatedIT.java
@@ -4,7 +4,6 @@ import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromAft
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromBefore;
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromJson;
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromKeyField;
-import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractPkFromNameField;
 
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
@@ -42,24 +41,17 @@ public class CdcIncludeBeforeAfterOnlyUpdatedIT extends CdcIncludeBeforeAfterBas
 
   @Override
   protected int extractPkFromValue(String value) {
-    // First try to extract from "after" field
     int pk = extractIdFromAfter(value);
     if (pk != -1) {
       return pk;
     }
-    // Then try "before" field (for DELETE records)
     pk = extractIdFromBefore(value);
     if (pk != -1) {
       return pk;
     }
     // For DELETE on partition-key-only tables, before/after are null.
     // Extract from the "key" field instead.
-    pk = extractIdFromKeyField(value);
-    if (pk != -1) {
-      return pk;
-    }
-    // Fallback to name field parsing
-    return extractPkFromNameField(value);
+    return extractIdFromKeyField(value);
   }
 
   @Override
@@ -68,28 +60,18 @@ public class CdcIncludeBeforeAfterOnlyUpdatedIT extends CdcIncludeBeforeAfterBas
   }
 
   /**
-   * INSERT: before=null, after=full image.
+   * INSERT: before=null, after=full image with all columns.
    *
    * <p>For INSERT operations, the "only-updated" mode has no effect because there is no previous
    * state. The after struct contains all columns with their values.
    */
   @Override
   String[] expectedInsert(int pk) {
-    return new String[] {
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, insertNameValue(pk), insertValueValue(pk), expectedSource())
-    };
+    return new String[] {buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())};
   }
 
   /**
-   * DELETE: before=null, after=null.
+   * DELETE: before=null (partition delete has no preimage), after=null.
    *
    * <p>This table has only a partition key (no clustering key), so DELETE operations are
    * represented as PARTITION_DELETE by Scylla CDC. Scylla doesn't send preimage for partition
@@ -98,101 +80,45 @@ public class CdcIncludeBeforeAfterOnlyUpdatedIT extends CdcIncludeBeforeAfterBas
   @Override
   String[] expectedDelete(int pk) {
     return new String[] {
-      // INSERT record (CREATE operation)
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, deleteNameValue(pk), deleteValueValue(pk), expectedSource()),
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
       // DELETE record: before=null because Scylla doesn't send preimage for PARTITION_DELETE
-      """
-        {
-          "before": null,
-          "after": null,
-          "key": {"id": %d},
-          "op": "d",
-          "source": %s
-        }
-        """
-          .formatted(pk, expectedSource()),
+      buildDeleteRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
       // Tombstone record (null value) for Kafka log compaction
       null
     };
   }
 
   /**
-   * UPDATE (single column): before and after contain only modified column + PK.
+   * UPDATE (partial - only some primitives modified): before and after contain only modified
+   * columns + PK.
    *
-   * <p>When only the "name" column is updated, the "value" column should NOT appear in either the
-   * before or after structs. Only the modified "name" column (plus PK) should be present.
+   * <p>In "only-updated" mode, only the columns that were actually modified appear in before/after.
+   * Untouched columns are excluded.
    */
   @Override
   String[] expectedUpdate(int pk) {
     return new String[] {
-      // INSERT record (CREATE operation)
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, updateBeforeNameValue(pk), updateBeforeValueValue(pk), expectedSource()),
-      // UPDATE record - only modified column (name) + PK in before/after
-      // The "value" column should NOT be present since it was not modified
-      """
-        {
-          "before": {"id": %d, "name": "%s"},
-          "after": {"id": %d, "name": "%s"},
-          "op": "u",
-          "source": %s
-        }
-        """
-          .formatted(pk, updateBeforeNameValue(pk), pk, updateAfterNameValue(pk), expectedSource())
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
+      // UPDATE record - only modified columns in before/after
+      buildUpdateRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())
     };
   }
 
   /**
-   * UPDATE (multiple columns): before and after contain all modified columns + PK.
+   * UPDATE (all active columns modified): before and after contain all modified columns + PK.
    *
-   * <p>When both "name" and "value" columns are updated, both should appear in the before and after
-   * structs (along with PK).
+   * <p>When all active columns are modified, they all appear in before/after, but untouched columns
+   * are still excluded.
    */
   @Override
   String[] expectedUpdateMultiColumn(int pk) {
     return new String[] {
-      // INSERT record (CREATE operation)
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, updateBeforeNameValue(pk), updateBeforeValueValue(pk), expectedSource()),
-      // UPDATE record - both modified columns (name, value) + PK in before/after
-      """
-        {
-          "before": {"id": %d, "name": "%s", "value": %d},
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "u",
-          "source": %s
-        }
-        """
-          .formatted(
-              pk,
-              updateBeforeNameValue(pk),
-              updateBeforeValueValue(pk),
-              pk,
-              updateAfterNameValue(pk),
-              updateAfterValueValue(pk),
-              expectedSource())
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
+      // UPDATE record - all active columns in before/after (untouched excluded)
+      buildUpdateMultiColumnRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())
     };
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeFullAfterOnlyUpdatedIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/CdcIncludeBeforeFullAfterOnlyUpdatedIT.java
@@ -4,7 +4,6 @@ import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromAft
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromBefore;
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromJson;
 import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromKeyField;
-import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractPkFromNameField;
 
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
@@ -56,11 +55,7 @@ public class CdcIncludeBeforeFullAfterOnlyUpdatedIT
     }
     // For DELETE on partition-key-only tables, before/after are null.
     // Extract from the "key" field instead.
-    pk = extractIdFromKeyField(value);
-    if (pk != -1) {
-      return pk;
-    }
-    return extractPkFromNameField(value);
+    return extractIdFromKeyField(value);
   }
 
   @Override
@@ -69,27 +64,17 @@ public class CdcIncludeBeforeFullAfterOnlyUpdatedIT
   }
 
   /**
-   * INSERT: before=null, after=full image.
+   * INSERT: before=null, after=full image with all columns.
    *
    * <p>INSERT always uses full image for after, regardless of the only-updated setting.
    */
   @Override
   String[] expectedInsert(int pk) {
-    return new String[] {
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, insertNameValue(pk), insertValueValue(pk), expectedSource())
-    };
+    return new String[] {buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())};
   }
 
   /**
-   * DELETE: before=null, after=null.
+   * DELETE: before=null (partition delete has no preimage), after=null.
    *
    * <p>This table has only a partition key (no clustering key), so DELETE operations are
    * represented as PARTITION_DELETE by Scylla CDC. Scylla doesn't send preimage for partition
@@ -98,109 +83,44 @@ public class CdcIncludeBeforeFullAfterOnlyUpdatedIT
   @Override
   String[] expectedDelete(int pk) {
     return new String[] {
-      // INSERT record
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, deleteNameValue(pk), deleteValueValue(pk), expectedSource()),
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
       // DELETE record: before=null because Scylla doesn't send preimage for PARTITION_DELETE
-      """
-        {
-          "before": null,
-          "after": null,
-          "key": {"id": %d},
-          "op": "d",
-          "source": %s
-        }
-        """
-          .formatted(pk, expectedSource()),
+      buildDeleteRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
       // Tombstone record (null value) for Kafka log compaction
       null
     };
   }
 
   /**
-   * UPDATE (single column): before=full image, after=only modified column + PK.
+   * UPDATE (partial): before=full image, after=only modified columns + PK.
    *
    * <p>Mixed mode: before contains ALL columns (full state), but after contains only the modified
-   * "name" column (no "value" column since it wasn't modified).
+   * columns (untouched columns excluded).
    */
   @Override
   String[] expectedUpdate(int pk) {
     return new String[] {
-      // INSERT record
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, updateBeforeNameValue(pk), updateBeforeValueValue(pk), expectedSource()),
-      // UPDATE record:
-      // - before: FULL (all columns including unchanged "value")
-      // - after: ONLY-UPDATED (just "name" + PK, no "value")
-      """
-        {
-          "before": {"id": %d, "name": "%s", "value": %d},
-          "after": {"id": %d, "name": "%s"},
-          "op": "u",
-          "source": %s
-        }
-        """
-          .formatted(
-              pk,
-              updateBeforeNameValue(pk),
-              updateBeforeValueValue(pk),
-              pk,
-              updateAfterNameValue(pk),
-              expectedSource())
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
+      // UPDATE record: before=full, after=only-updated
+      buildUpdateRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())
     };
   }
 
   /**
-   * UPDATE (multiple columns): before=full image, after=all modified columns + PK.
+   * UPDATE (all active columns): before=full image, after=all modified columns + PK.
    *
-   * <p>When all non-key columns are modified, the after struct will contain all of them.
+   * <p>When all active columns are modified, the after struct will contain all of them, but
+   * untouched columns are still excluded from after.
    */
   @Override
   String[] expectedUpdateMultiColumn(int pk) {
     return new String[] {
-      // INSERT record
-      """
-        {
-          "before": null,
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "c",
-          "source": %s
-        }
-        """
-          .formatted(pk, updateBeforeNameValue(pk), updateBeforeValueValue(pk), expectedSource()),
-      // UPDATE record:
-      // - before: FULL (all columns)
-      // - after: ONLY-UPDATED (both modified columns + PK)
-      """
-        {
-          "before": {"id": %d, "name": "%s", "value": %d},
-          "after": {"id": %d, "name": "%s", "value": %d},
-          "op": "u",
-          "source": %s
-        }
-        """
-          .formatted(
-              pk,
-              updateBeforeNameValue(pk),
-              updateBeforeValueValue(pk),
-              pk,
-              updateAfterNameValue(pk),
-              updateAfterValueValue(pk),
-              expectedSource())
+      // INSERT record with full image
+      buildInsertRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource()),
+      // UPDATE record: before=full, after=only-updated (all active)
+      buildUpdateMultiColumnRecord(pk, BEFORE_MODE, AFTER_MODE, expectedSource())
     };
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/FrozenCollectionsAvroSchemaTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/FrozenCollectionsAvroSchemaTest.java
@@ -1,0 +1,432 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.debezium.data.SchemaUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test to verify that frozen collections schemas are valid and can be converted to Avro
+ * format. This tests the schema construction to ensure all struct types have proper names which is
+ * required for Avro serialization.
+ */
+public class FrozenCollectionsAvroSchemaTest {
+
+  @Test
+  void testSimpleMapSchemaHasName() {
+    // Create a simple map schema (frozen<map<int, text>>)
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapSchema = SchemaBuilder.array(mapEntrySchema).optional().build();
+
+    // Verify schema has a name (required for Avro)
+    assertNotNull(mapEntrySchema.name(), "Map entry schema should have a name");
+    System.out.println("Map entry schema name: " + mapEntrySchema.name());
+
+    // Create the value schema
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_map_col", mapSchema)
+            .optional()
+            .build();
+
+    assertNotNull(valueSchema.name(), "Value schema should have a name");
+    System.out.println("Value schema: " + SchemaUtil.asString(valueSchema));
+  }
+
+  @Test
+  void testTupleSchemaHasName() {
+    // Create a tuple schema (frozen<tuple<int, text>>) with Avro-compatible field names
+    Schema tupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("field_0", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("field_1", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    // Verify schema has a name (required for Avro)
+    assertNotNull(tupleSchema.name(), "Tuple schema should have a name");
+    System.out.println("Tuple schema name: " + tupleSchema.name());
+  }
+
+  @Test
+  void testMapWithTupleKeySchemaHasNames() {
+    // Create a tuple schema for map keys
+    Schema tupleKeySchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("0", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("1", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    // Create map entry with tuple key
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_Tuple_INT_TEXT_TEXT")
+            .field("key", tupleKeySchema)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    assertNotNull(tupleKeySchema.name(), "Tuple key schema should have a name");
+    assertNotNull(mapEntrySchema.name(), "Map entry schema should have a name");
+    System.out.println("Tuple key schema name: " + tupleKeySchema.name());
+    System.out.println("Map entry schema name: " + mapEntrySchema.name());
+  }
+
+  @Test
+  void testUdtSchemaHasName() {
+    // Create a UDT schema (frozen<map_key_udt>)
+    Schema udtSchema =
+        SchemaBuilder.struct()
+            .name("UDT_map_key_udt")
+            .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    assertNotNull(udtSchema.name(), "UDT schema should have a name");
+    System.out.println("UDT schema name: " + udtSchema.name());
+  }
+
+  @Test
+  void testFullFrozenCollectionsSchemaStructure() {
+    // Test all frozen collections in a single schema like the actual table
+    Schema listSchema = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build();
+    Schema setSchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+
+    // frozen<map<int, text>>
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapSchema = SchemaBuilder.array(mapEntrySchema).optional().build();
+
+    // frozen<tuple<int, text>>
+    Schema tupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("0", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("1", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    // frozen<map<frozen<tuple<int, text>>, text>>
+    Schema mapTupleEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_Tuple_INT_TEXT_TEXT")
+            .field("key", tupleSchema)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapTupleSchema = SchemaBuilder.array(mapTupleEntrySchema).optional().build();
+
+    // UDT schema
+    Schema udtSchema =
+        SchemaBuilder.struct()
+            .name("UDT_map_key_udt")
+            .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    // frozen<map<frozen<map_key_udt>, text>>
+    Schema mapUdtEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_UDT_map_key_udt_TEXT")
+            .field("key", udtSchema)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapUdtSchema = SchemaBuilder.array(mapUdtEntrySchema).optional().build();
+
+    // Create the value schema
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_list_col", listSchema)
+            .field("frozen_set_col", setSchema)
+            .field("frozen_map_col", mapSchema)
+            .field("frozen_tuple_col", tupleSchema)
+            .field("frozen_map_tuple_key_col", mapTupleSchema)
+            .field("frozen_map_udt_key_col", mapUdtSchema)
+            .optional()
+            .build();
+
+    // Verify all struct schemas have names
+    assertNotNull(mapEntrySchema.name());
+    assertNotNull(tupleSchema.name());
+    assertNotNull(mapTupleEntrySchema.name());
+    assertNotNull(udtSchema.name());
+    assertNotNull(mapUdtEntrySchema.name());
+    assertNotNull(valueSchema.name());
+
+    System.out.println("Full schema: " + SchemaUtil.asString(valueSchema));
+  }
+
+  @Test
+  void testStructCreation() {
+    // Test that we can create structs with these schemas and populate them
+    Schema tupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("0", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("1", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_Tuple_INT_TEXT_TEXT")
+            .field("key", tupleSchema)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapSchema = SchemaBuilder.array(mapEntrySchema).optional().build();
+
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_map_tuple_key_col", mapSchema)
+            .optional()
+            .build();
+
+    // Create structs with data
+    assertDoesNotThrow(
+        () -> {
+          Struct tupleKey = new Struct(tupleSchema);
+          tupleKey.put("0", 1);
+          tupleKey.put("1", "tuple_key");
+
+          Struct mapEntry = new Struct(mapEntrySchema);
+          mapEntry.put("key", tupleKey);
+          mapEntry.put("value", "tuple_value");
+
+          List<Struct> mapEntries = new ArrayList<>();
+          mapEntries.add(mapEntry);
+
+          Struct value = new Struct(valueSchema);
+          value.put("id", 1);
+          value.put("frozen_map_tuple_key_col", mapEntries);
+
+          System.out.println("Struct created successfully");
+        });
+  }
+
+  @Test
+  void testEmptyCollectionsStruct() {
+    // Test the testInsertWithEmpty scenario - empty collections
+    Schema listSchema = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build();
+    Schema setSchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapSchema = SchemaBuilder.array(mapEntrySchema).optional().build();
+
+    Schema tupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("0", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("1", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_list_col", listSchema)
+            .field("frozen_set_col", setSchema)
+            .field("frozen_map_col", mapSchema)
+            .field("frozen_tuple_col", tupleSchema)
+            .optional()
+            .build();
+
+    assertDoesNotThrow(
+        () -> {
+          Struct value = new Struct(valueSchema);
+          value.put("id", 1);
+          value.put("frozen_list_col", new ArrayList<>());
+          value.put("frozen_set_col", new ArrayList<>());
+          value.put("frozen_map_col", new ArrayList<>());
+
+          // Empty tuple with null fields
+          Struct emptyTuple = new Struct(tupleSchema);
+          emptyTuple.put("0", null);
+          emptyTuple.put("1", null);
+          value.put("frozen_tuple_col", emptyTuple);
+
+          System.out.println("Empty collections struct created successfully");
+        });
+  }
+
+  @Test
+  void testDuplicateSchemaNames() {
+    // Test what happens when same schema name appears multiple times
+    // This simulates the actual table which has:
+    // - frozen_map_col (map<int, text>) -> MapEntry_INT_TEXT
+    // - frozen_map_int_col (map<int, text>) -> MapEntry_INT_TEXT
+    // - frozen_tuple_col (tuple<int, text>) -> Tuple_INT_TEXT
+    // - frozen_map_tuple_key_col (map<tuple<int, text>, text>) -> key = Tuple_INT_TEXT
+
+    // Create two separate Schema objects with the same name
+    Schema mapEntrySchema1 =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    // Second schema with same name - this is what happens when each column
+    // creates its own schema object
+    Schema mapEntrySchema2 =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    Schema mapSchema1 = SchemaBuilder.array(mapEntrySchema1).optional().build();
+    Schema mapSchema2 = SchemaBuilder.array(mapEntrySchema2).optional().build();
+
+    // Check if the schemas are equal
+    System.out.println(
+        "mapEntrySchema1 == mapEntrySchema2: " + (mapEntrySchema1 == mapEntrySchema2));
+    System.out.println(
+        "mapEntrySchema1.equals(mapEntrySchema2): " + mapEntrySchema1.equals(mapEntrySchema2));
+
+    // Create a value schema with both map columns using different schema objects
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_map_col", mapSchema1)
+            .field("frozen_map_int_col", mapSchema2)
+            .optional()
+            .build();
+
+    System.out.println("Value schema with duplicate names: " + valueSchema);
+    System.out.println("Number of fields: " + valueSchema.fields().size());
+    for (org.apache.kafka.connect.data.Field f : valueSchema.fields()) {
+      Schema fieldSchema = f.schema();
+      String innerSchemaName =
+          fieldSchema.type() == Schema.Type.ARRAY ? fieldSchema.valueSchema().name() : null;
+      System.out.println(
+          "  Field: "
+              + f.name()
+              + " type: "
+              + fieldSchema.type()
+              + " inner schema name: "
+              + innerSchemaName);
+    }
+
+    // Try to create a struct
+    assertDoesNotThrow(
+        () -> {
+          Struct value = new Struct(valueSchema);
+          value.put("id", 1);
+          value.put("frozen_map_col", new ArrayList<>());
+          value.put("frozen_map_int_col", new ArrayList<>());
+        });
+
+    System.out.println("Struct with duplicate schema names created successfully");
+  }
+
+  @Test
+  void testSharedSchemaInstance() {
+    // Test that using the same schema instance works better
+    Schema mapEntrySchema =
+        SchemaBuilder.struct()
+            .name("MapEntry_INT_TEXT")
+            .field("key", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    // Reuse the same schema for both arrays
+    Schema mapSchema1 = SchemaBuilder.array(mapEntrySchema).optional().build();
+    Schema mapSchema2 = SchemaBuilder.array(mapEntrySchema).optional().build();
+
+    Schema valueSchema =
+        SchemaBuilder.struct()
+            .name("test.TestTable.Value")
+            .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("frozen_map_col", mapSchema1)
+            .field("frozen_map_int_col", mapSchema2)
+            .optional()
+            .build();
+
+    System.out.println("Value schema with shared entry schema: " + valueSchema);
+
+    assertDoesNotThrow(
+        () -> {
+          Struct value = new Struct(valueSchema);
+          value.put("id", 1);
+          value.put("frozen_map_col", new ArrayList<>());
+          value.put("frozen_map_int_col", new ArrayList<>());
+        });
+
+    System.out.println("Struct with shared schema instance created successfully");
+  }
+
+  @Test
+  void testAvroFieldNameValidity() {
+    // Avro field names must match: [A-Za-z_][A-Za-z0-9_]*
+    // Field names starting with digits (like "0", "1") are INVALID in Avro!
+
+    // This is the current problematic tuple schema with numeric field names
+    Schema badTupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("0", Schema.OPTIONAL_INT32_SCHEMA) // INVALID: starts with digit
+            .field("1", Schema.OPTIONAL_STRING_SCHEMA) // INVALID: starts with digit
+            .optional()
+            .build();
+
+    // This is the correct tuple schema with valid Avro field names
+    Schema goodTupleSchema =
+        SchemaBuilder.struct()
+            .name("Tuple_INT_TEXT")
+            .field("field_0", Schema.OPTIONAL_INT32_SCHEMA) // VALID
+            .field("field_1", Schema.OPTIONAL_STRING_SCHEMA) // VALID
+            .optional()
+            .build();
+
+    System.out.println("Bad tuple schema (numeric field names): " + badTupleSchema);
+    System.out.println("Good tuple schema (prefixed field names): " + goodTupleSchema);
+
+    // Both schemas work for Kafka Connect Struct - but only the good one works with Avro
+    assertDoesNotThrow(
+        () -> {
+          Struct badTuple = new Struct(badTupleSchema);
+          badTuple.put("0", 42);
+          badTuple.put("1", "foo");
+          System.out.println("Bad tuple struct created (works in Connect, fails in Avro)");
+        });
+
+    assertDoesNotThrow(
+        () -> {
+          Struct goodTuple = new Struct(goodTupleSchema);
+          goodTuple.put("field_0", 42);
+          goodTuple.put("field_1", "foo");
+          System.out.println("Good tuple struct created (works in Connect AND Avro)");
+        });
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsAvroConnectorIT.java
@@ -1,0 +1,494 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildAvroConnector;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesFrozenCollectionsAvroConnectorIT
+    extends ScyllaTypesFrozenCollectionsBase<GenericRecord, GenericRecord> {
+
+  @BeforeAll
+  @Override
+  public void setupSuite(TestInfo testInfo) {
+    Assumptions.assumeTrue(
+        KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
+    Assumptions.assumeTrue(
+        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
+        "Avro tests require distributed mode, otherwise Avro converter is not available");
+    super.setupSuite(testInfo);
+  }
+
+  @Override
+  KafkaConsumer<GenericRecord, GenericRecord> buildConsumer(
+      String connectorName, String tableName) {
+    return buildAvroConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(GenericRecord value) {
+    return extractIdFromKeyField(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(GenericRecord key) {
+    return extractIdFromRecord(key);
+  }
+
+  private int extractIdFromKeyField(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "key" field first (payload-key)
+    if (record.getSchema().getField("key") != null) {
+      Object key = record.get("key");
+      if (key instanceof GenericRecord) {
+        GenericRecord keyRecord = (GenericRecord) key;
+        if (keyRecord.getSchema().getField("id") != null) {
+          Object id = keyRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to after/before/direct for backwards compatibility
+    return extractIdFromRecord(record);
+  }
+
+  private int extractIdFromRecord(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "after" field first (standard Debezium envelope)
+    if (record.getSchema().getField("after") != null) {
+      Object after = record.get("after");
+      if (after instanceof GenericRecord) {
+        GenericRecord afterRecord = (GenericRecord) after;
+        if (afterRecord.getSchema().getField("id") != null) {
+          Object id = afterRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Try "before" field (for delete operations)
+    if (record.getSchema().getField("before") != null) {
+      Object before = record.get("before");
+      if (before instanceof GenericRecord) {
+        GenericRecord beforeRecord = (GenericRecord) before;
+        if (beforeRecord.getSchema().getField("id") != null) {
+          Object id = beforeRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to direct "id" field (for keys)
+    if (record.getSchema().getField("id") != null) {
+      Object id = record.get("id");
+      if (id instanceof Number) {
+        return ((Number) id).intValue();
+      }
+    }
+    return -1;
+  }
+
+  /** Returns the full "after" JSON for an insert with values. */
+  private String afterInsertWithValues(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the full "after" JSON for an update with new values. */
+  private String afterUpdateWithValues(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [4, 5, 6],
+          "frozen_set_col": ["x", "y", "z"],
+          "frozen_map_col": [{"key": 3, "value": "three"}, {"key": 4, "value": "four"}],
+          "frozen_tuple_col": {"field_0": 99, "field_1": "bar"},
+          "frozen_map_ascii_col": [{"key": "ascii_key_2", "value": "ascii_value_2"}],
+          "frozen_map_bigint_col": [{"key": 1234567890124, "value": "bigint_value_2"}],
+          "frozen_map_boolean_col": [{"key": false, "value": "boolean_value_2"}],
+          "frozen_map_date_col": [{"key": 19885, "value": "date_value_2"}],
+          "frozen_map_decimal_col": [{"key": "98765.43", "value": "decimal_value_2"}],
+          "frozen_map_double_col": [{"key": 2.71828, "value": "double_value_2"}],
+          "frozen_map_float_col": [{"key": 1.41421, "value": "float_value_2"}],
+          "frozen_map_int_col": [{"key": 43, "value": "int_value_2"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.2", "value": "inet_value_2"}],
+          "frozen_map_smallint_col": [{"key": 8, "value": "smallint_value_2"}],
+          "frozen_map_text_col": [{"key": "text_key_2", "value": "text_value_2"}],
+          "frozen_map_time_col": [{"key": 3723456000000, "value": "time_value_2"}],
+          "frozen_map_timestamp_col": [{"key": 1718067723456, "value": "timestamp_value_2"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value_2"}],
+          "frozen_map_tinyint_col": [{"key": 6, "value": "tinyint_value_2"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371d", "value": "uuid_value_2"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key_2", "value": "varchar_value_2"}],
+          "frozen_map_varint_col": [{"key": "888888888", "value": "varint_value_2"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 2, "field_1": "tuple_key_2"}, "value": "tuple_value_2"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 2, "b": "udt_key_2"}, "value": "udt_value_2"}],
+          "frozen_set_timeuuid_col": ["81d4a031-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for empty collections. */
+  private String afterEmpty(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [],
+          "frozen_set_col": [],
+          "frozen_map_col": [],
+          "frozen_tuple_col": {"field_0": null, "field_1": null},
+          "frozen_map_ascii_col": [],
+          "frozen_map_bigint_col": [],
+          "frozen_map_boolean_col": [],
+          "frozen_map_date_col": [],
+          "frozen_map_decimal_col": [],
+          "frozen_map_double_col": [],
+          "frozen_map_float_col": [],
+          "frozen_map_int_col": [],
+          "frozen_map_inet_col": [],
+          "frozen_map_smallint_col": [],
+          "frozen_map_text_col": [],
+          "frozen_map_time_col": [],
+          "frozen_map_timestamp_col": [],
+          "frozen_map_timeuuid_col": [],
+          "frozen_map_tinyint_col": [],
+          "frozen_map_uuid_col": [],
+          "frozen_map_varchar_col": [],
+          "frozen_map_varint_col": [],
+          "frozen_map_tuple_key_col": [],
+          "frozen_map_udt_key_col": [],
+          "frozen_set_timeuuid_col": []
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for null collections (when inserting with explicit null tuple). */
+  private String afterNull(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for completely null collections (when inserting only pk). */
+  private String afterAllNull(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the expected key JSON. */
+  private String expectedKeyFor(int pk) {
+    return "{\"id\": %d}".formatted(pk);
+  }
+
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterEmpty(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterNull(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": null,
+          "after": null,
+          "key": %s,
+          "op": "d",
+          "source": %s
+        }
+        """
+          .formatted(expectedKeyFor(pk), expectedSource()),
+      null
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(
+              afterInsertWithValues(pk),
+              afterUpdateWithValues(pk),
+              expectedKeyFor(pk),
+              expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(
+              afterInsertWithValues(pk), afterEmpty(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(
+              afterInsertWithValues(pk), afterAllNull(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterEmpty(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(
+              afterEmpty(pk), afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": %s,
+          "key": %s,
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(afterAllNull(pk), expectedKeyFor(pk), expectedSource()),
+      """
+        {
+          "before": %s,
+          "after": %s,
+          "key": %s,
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(
+              afterAllNull(pk), afterInsertWithValues(pk), expectedKeyFor(pk), expectedSource())
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsBase.java
@@ -1,0 +1,380 @@
+package com.scylladb.cdc.debezium.connector;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for frozen collections replication. Tests insert, update, and delete operations
+ * with frozen collection types (list, set, map, tuple).
+ *
+ * <p>Each test uses a unique primary key (obtained via {@link #reservePk()}) for isolation,
+ * allowing all tests to share a single connector and table.
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
+public abstract class ScyllaTypesFrozenCollectionsBase<K, V> extends ScyllaTypesIT<K, V> {
+
+  private static final String INSERT_COLUMNS =
+      "id, frozen_list_col, frozen_set_col, frozen_map_col, frozen_tuple_col, "
+          + "frozen_map_ascii_col, frozen_map_bigint_col, frozen_map_boolean_col, "
+          + "frozen_map_date_col, frozen_map_decimal_col, frozen_map_double_col, "
+          + "frozen_map_float_col, frozen_map_int_col, frozen_map_inet_col, "
+          + "frozen_map_smallint_col, frozen_map_text_col, frozen_map_time_col, "
+          + "frozen_map_timestamp_col, frozen_map_timeuuid_col, frozen_map_tinyint_col, "
+          + "frozen_map_uuid_col, frozen_map_varchar_col, frozen_map_varint_col, "
+          + "frozen_map_tuple_key_col, frozen_map_udt_key_col, frozen_set_timeuuid_col";
+
+  private static String valuesWithValues(int pk) {
+    return pk
+        + ", [1, 2, 3], {'a', 'b', 'c'}, {1: 'one', 2: 'two'}, (42, 'foo'), "
+        + "{'ascii_key': 'ascii_value'}, {1234567890123: 'bigint_value'}, "
+        + "{true: 'boolean_value'}, {'2024-06-10': 'date_value'}, "
+        + "{12345.67: 'decimal_value'}, {3.14159: 'double_value'}, "
+        + "{2.71828: 'float_value'}, {42: 'int_value'}, "
+        + "{'127.0.0.1': 'inet_value'}, {7: 'smallint_value'}, "
+        + "{'text_key': 'text_value'}, {'12:34:56.789': 'time_value'}, "
+        + "{'2024-06-10T12:34:56.789Z': 'timestamp_value'}, "
+        + "{81d4a030-4632-11f0-9484-409dd8f36eba: 'timeuuid_value'}, "
+        + "{5: 'tinyint_value'}, {453662fa-db4b-4938-9033-d8523c0a371c: 'uuid_value'}, "
+        + "{'varchar_key': 'varchar_value'}, {999999999: 'varint_value'}, "
+        + "{(1, 'tuple_key'): 'tuple_value'}, {{a: 1, b: 'udt_key'}: 'udt_value'}, "
+        + "{81d4a030-4632-11f0-9484-409dd8f36eba}";
+  }
+
+  private static String valuesWithEmpty(int pk) {
+    return pk
+        + ", [], {}, {}, (null, null), "
+        + "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}";
+  }
+
+  private static String valuesWithNull(int pk) {
+    return pk
+        + ", null, null, null, null, "
+        + "null, null, null, null, null, null, null, null, null, null, null, null, "
+        + "null, null, null, null, null, null, null, null, null";
+  }
+
+  private static final String UPDATE_SET_VALUES =
+      "frozen_list_col = [4, 5, 6], frozen_set_col = {'x', 'y', 'z'}, "
+          + "frozen_map_col = {3: 'three', 4: 'four'}, frozen_tuple_col = (99, 'bar'), "
+          + "frozen_map_ascii_col = {'ascii_key_2': 'ascii_value_2'}, "
+          + "frozen_map_bigint_col = {1234567890124: 'bigint_value_2'}, "
+          + "frozen_map_boolean_col = {false: 'boolean_value_2'}, "
+          + "frozen_map_date_col = {'2024-06-11': 'date_value_2'}, "
+          + "frozen_map_decimal_col = {98765.43: 'decimal_value_2'}, "
+          + "frozen_map_double_col = {2.71828: 'double_value_2'}, "
+          + "frozen_map_float_col = {1.41421: 'float_value_2'}, "
+          + "frozen_map_int_col = {43: 'int_value_2'}, "
+          + "frozen_map_inet_col = {'127.0.0.2': 'inet_value_2'}, "
+          + "frozen_map_smallint_col = {8: 'smallint_value_2'}, "
+          + "frozen_map_text_col = {'text_key_2': 'text_value_2'}, "
+          + "frozen_map_time_col = {'01:02:03.456': 'time_value_2'}, "
+          + "frozen_map_timestamp_col = {'2024-06-11T01:02:03.456Z': 'timestamp_value_2'}, "
+          + "frozen_map_timeuuid_col = {81d4a031-4632-11f0-9484-409dd8f36eba: 'timeuuid_value_2'}, "
+          + "frozen_map_tinyint_col = {6: 'tinyint_value_2'}, "
+          + "frozen_map_uuid_col = {453662fa-db4b-4938-9033-d8523c0a371d: 'uuid_value_2'}, "
+          + "frozen_map_varchar_col = {'varchar_key_2': 'varchar_value_2'}, "
+          + "frozen_map_varint_col = {888888888: 'varint_value_2'}, "
+          + "frozen_map_tuple_key_col = {(2, 'tuple_key_2'): 'tuple_value_2'}, "
+          + "frozen_map_udt_key_col = {{a: 2, b: 'udt_key_2'}: 'udt_value_2'}, "
+          + "frozen_set_timeuuid_col = {81d4a031-4632-11f0-9484-409dd8f36eba}";
+
+  private static final String UPDATE_SET_INITIAL_VALUES =
+      "frozen_list_col = [1, 2, 3], frozen_set_col = {'a', 'b', 'c'}, "
+          + "frozen_map_col = {1: 'one', 2: 'two'}, frozen_tuple_col = (42, 'foo'), "
+          + "frozen_map_ascii_col = {'ascii_key': 'ascii_value'}, "
+          + "frozen_map_bigint_col = {1234567890123: 'bigint_value'}, "
+          + "frozen_map_boolean_col = {true: 'boolean_value'}, "
+          + "frozen_map_date_col = {'2024-06-10': 'date_value'}, "
+          + "frozen_map_decimal_col = {12345.67: 'decimal_value'}, "
+          + "frozen_map_double_col = {3.14159: 'double_value'}, "
+          + "frozen_map_float_col = {2.71828: 'float_value'}, "
+          + "frozen_map_int_col = {42: 'int_value'}, "
+          + "frozen_map_inet_col = {'127.0.0.1': 'inet_value'}, "
+          + "frozen_map_smallint_col = {7: 'smallint_value'}, "
+          + "frozen_map_text_col = {'text_key': 'text_value'}, "
+          + "frozen_map_time_col = {'12:34:56.789': 'time_value'}, "
+          + "frozen_map_timestamp_col = {'2024-06-10T12:34:56.789Z': 'timestamp_value'}, "
+          + "frozen_map_timeuuid_col = {81d4a030-4632-11f0-9484-409dd8f36eba: 'timeuuid_value'}, "
+          + "frozen_map_tinyint_col = {5: 'tinyint_value'}, "
+          + "frozen_map_uuid_col = {453662fa-db4b-4938-9033-d8523c0a371c: 'uuid_value'}, "
+          + "frozen_map_varchar_col = {'varchar_key': 'varchar_value'}, "
+          + "frozen_map_varint_col = {999999999: 'varint_value'}, "
+          + "frozen_map_tuple_key_col = {(1, 'tuple_key'): 'tuple_value'}, "
+          + "frozen_map_udt_key_col = {{a: 1, b: 'udt_key'}: 'udt_value'}, "
+          + "frozen_set_timeuuid_col = {81d4a030-4632-11f0-9484-409dd8f36eba}";
+
+  private static final String UPDATE_SET_EMPTY =
+      "frozen_list_col = [], frozen_set_col = {}, "
+          + "frozen_map_col = {}, frozen_tuple_col = (null, null), "
+          + "frozen_map_ascii_col = {}, frozen_map_bigint_col = {}, "
+          + "frozen_map_boolean_col = {}, frozen_map_date_col = {}, "
+          + "frozen_map_decimal_col = {}, frozen_map_double_col = {}, "
+          + "frozen_map_float_col = {}, frozen_map_int_col = {}, "
+          + "frozen_map_inet_col = {}, frozen_map_smallint_col = {}, "
+          + "frozen_map_text_col = {}, frozen_map_time_col = {}, "
+          + "frozen_map_timestamp_col = {}, frozen_map_timeuuid_col = {}, "
+          + "frozen_map_tinyint_col = {}, frozen_map_uuid_col = {}, "
+          + "frozen_map_varchar_col = {}, frozen_map_varint_col = {}, "
+          + "frozen_map_tuple_key_col = {}, frozen_map_udt_key_col = {}, "
+          + "frozen_set_timeuuid_col = {}";
+
+  private static final String UPDATE_SET_NULL =
+      "frozen_list_col = null, frozen_set_col = null, "
+          + "frozen_map_col = null, frozen_tuple_col = null, "
+          + "frozen_map_ascii_col = null, frozen_map_bigint_col = null, "
+          + "frozen_map_boolean_col = null, frozen_map_date_col = null, "
+          + "frozen_map_decimal_col = null, frozen_map_double_col = null, "
+          + "frozen_map_float_col = null, frozen_map_int_col = null, "
+          + "frozen_map_inet_col = null, frozen_map_smallint_col = null, "
+          + "frozen_map_text_col = null, frozen_map_time_col = null, "
+          + "frozen_map_timestamp_col = null, frozen_map_timeuuid_col = null, "
+          + "frozen_map_tinyint_col = null, frozen_map_uuid_col = null, "
+          + "frozen_map_varchar_col = null, frozen_map_varint_col = null, "
+          + "frozen_map_tuple_key_col = null, frozen_map_udt_key_col = null, "
+          + "frozen_set_timeuuid_col = null";
+
+  /** Returns expected records for an INSERT with all frozen collection values present. */
+  abstract String[] expectedInsertWithValues(int pk);
+
+  /** Returns expected records for an INSERT with empty frozen collections. */
+  abstract String[] expectedInsertWithEmpty(int pk);
+
+  /** Returns expected records for an INSERT with null frozen collections. */
+  abstract String[] expectedInsertWithNull(int pk);
+
+  /** Returns expected records for a DELETE of the row. */
+  abstract String[] expectedDelete(int pk);
+
+  /** Returns expected records for updating from values to values. */
+  abstract String[] expectedUpdateFromValueToValue(int pk);
+
+  /** Returns expected records for updating from values to empty collections. */
+  abstract String[] expectedUpdateFromValueToEmpty(int pk);
+
+  /** Returns expected records for updating from values to null collections. */
+  abstract String[] expectedUpdateFromValueToNull(int pk);
+
+  /** Returns expected records for updating from empty collections to values. */
+  abstract String[] expectedUpdateFromEmptyToValue(int pk);
+
+  /** Returns expected records for updating from null collections to values. */
+  abstract String[] expectedUpdateFromNullToValue(int pk);
+
+  /** {@inheritDoc} */
+  @Override
+  protected void createTypesBeforeTable(String keyspaceName) {
+    session.execute("CREATE TYPE IF NOT EXISTS " + keyspaceName + ".map_key_udt (a int, b text);");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String createTableCql(String tableName) {
+    return "("
+        + "id int PRIMARY KEY,"
+        + "frozen_list_col frozen<list<int>>,"
+        + "frozen_set_col frozen<set<text>>,"
+        + "frozen_map_col frozen<map<int, text>>,"
+        + "frozen_tuple_col frozen<tuple<int, text>>,"
+        + "frozen_map_ascii_col frozen<map<ascii, text>>,"
+        + "frozen_map_bigint_col frozen<map<bigint, text>>,"
+        + "frozen_map_boolean_col frozen<map<boolean, text>>,"
+        + "frozen_map_date_col frozen<map<date, text>>,"
+        + "frozen_map_decimal_col frozen<map<decimal, text>>,"
+        + "frozen_map_double_col frozen<map<double, text>>,"
+        + "frozen_map_float_col frozen<map<float, text>>,"
+        + "frozen_map_int_col frozen<map<int, text>>,"
+        + "frozen_map_inet_col frozen<map<inet, text>>,"
+        + "frozen_map_smallint_col frozen<map<smallint, text>>,"
+        + "frozen_map_text_col frozen<map<text, text>>,"
+        + "frozen_map_time_col frozen<map<time, text>>,"
+        + "frozen_map_timestamp_col frozen<map<timestamp, text>>,"
+        + "frozen_map_timeuuid_col frozen<map<timeuuid, text>>,"
+        + "frozen_map_tinyint_col frozen<map<tinyint, text>>,"
+        + "frozen_map_uuid_col frozen<map<uuid, text>>,"
+        + "frozen_map_varchar_col frozen<map<varchar, text>>,"
+        + "frozen_map_varint_col frozen<map<varint, text>>,"
+        + "frozen_map_tuple_key_col frozen<map<frozen<tuple<int, text>>, text>>,"
+        + "frozen_map_udt_key_col frozen<map<frozen<map_key_udt>, text>>,"
+        + "frozen_set_timeuuid_col frozen<set<timeuuid>>"
+        + ")";
+  }
+
+  /** Verifies an INSERT with frozen collection values emits expected records. */
+  @Test
+  void testInsertWithValues() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithValues(pk)
+            + ");");
+    String[] expected = expectedInsertWithValues(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies an INSERT with empty frozen collections emits expected records. */
+  @Test
+  void testInsertWithEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithEmpty(pk)
+            + ");");
+    String[] expected = expectedInsertWithEmpty(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies an INSERT with null frozen collections emits expected records. */
+  @Test
+  void testInsertWithNull() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithNull(pk)
+            + ");");
+    String[] expected = expectedInsertWithNull(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies a DELETE emits expected records. */
+  @Test
+  void testDelete() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithValues(pk)
+            + ");");
+    session.execute("DELETE FROM " + getSuiteKeyspaceTableName() + " WHERE id = " + pk + ";");
+    String[] expected = expectedDelete(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates from populated values to populated values emit expected records. */
+  @Test
+  void testUpdateFromValueToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithValues(pk)
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + UPDATE_SET_VALUES
+            + " WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateFromValueToValue(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates from populated values to empty collections emit expected records. */
+  @Test
+  void testUpdateFromValueToEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithValues(pk)
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + UPDATE_SET_EMPTY
+            + " WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateFromValueToEmpty(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates from populated values to null collections emit expected records. */
+  @Test
+  void testUpdateFromValueToNull() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithValues(pk)
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + UPDATE_SET_NULL
+            + " WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateFromValueToNull(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates from empty collections to populated values emit expected records. */
+  @Test
+  void testUpdateFromEmptyToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " ("
+            + INSERT_COLUMNS
+            + ") VALUES ("
+            + valuesWithEmpty(pk)
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + UPDATE_SET_INITIAL_VALUES
+            + " WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateFromEmptyToValue(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates from null collections to populated values emit expected records. */
+  @Test
+  void testUpdateFromNullToValue() {
+    int pk = reservePk();
+    session.execute("INSERT INTO " + getSuiteKeyspaceTableName() + " (id) VALUES (" + pk + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET "
+            + UPDATE_SET_INITIAL_VALUES
+            + " WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateFromNullToValue(pk);
+    waitAndAssert(pk, expected);
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsNewRecordStateConnectorIT.java
@@ -1,0 +1,557 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildScyllaExtractNewRecordStateConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesFrozenCollectionsNewRecordStateConnectorIT
+    extends ScyllaTypesFrozenCollectionsBase<String, String> {
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildScyllaExtractNewRecordStateConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [],
+          "frozen_set_col": [],
+          "frozen_map_col": [],
+          "frozen_tuple_col": {"field_0": null, "field_1": null},
+          "frozen_map_ascii_col": [],
+          "frozen_map_bigint_col": [],
+          "frozen_map_boolean_col": [],
+          "frozen_map_date_col": [],
+          "frozen_map_decimal_col": [],
+          "frozen_map_double_col": [],
+          "frozen_map_float_col": [],
+          "frozen_map_int_col": [],
+          "frozen_map_inet_col": [],
+          "frozen_map_smallint_col": [],
+          "frozen_map_text_col": [],
+          "frozen_map_time_col": [],
+          "frozen_map_timestamp_col": [],
+          "frozen_map_timeuuid_col": [],
+          "frozen_map_tinyint_col": [],
+          "frozen_map_uuid_col": [],
+          "frozen_map_varchar_col": [],
+          "frozen_map_varint_col": [],
+          "frozen_map_tuple_key_col": [],
+          "frozen_map_udt_key_col": [],
+          "frozen_set_timeuuid_col": []
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk),
+      // DELETE record - after is null, so the record is null
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    return new String[] {
+      // Preimage with original values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk),
+      // Postimage with updated values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [4, 5, 6],
+          "frozen_set_col": ["x", "y", "z"],
+          "frozen_map_col": [{"key": 3, "value": "three"}, {"key": 4, "value": "four"}],
+          "frozen_tuple_col": {"field_0": 99, "field_1": "bar"},
+          "frozen_map_ascii_col": [{"key": "ascii_key_2", "value": "ascii_value_2"}],
+          "frozen_map_bigint_col": [{"key": 1234567890124, "value": "bigint_value_2"}],
+          "frozen_map_boolean_col": [{"key": false, "value": "boolean_value_2"}],
+          "frozen_map_date_col": [{"key": 19885, "value": "date_value_2"}],
+          "frozen_map_decimal_col": [{"key": "98765.43", "value": "decimal_value_2"}],
+          "frozen_map_double_col": [{"key": 2.71828, "value": "double_value_2"}],
+          "frozen_map_float_col": [{"key": 1.41421, "value": "float_value_2"}],
+          "frozen_map_int_col": [{"key": 43, "value": "int_value_2"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.2", "value": "inet_value_2"}],
+          "frozen_map_smallint_col": [{"key": 8, "value": "smallint_value_2"}],
+          "frozen_map_text_col": [{"key": "text_key_2", "value": "text_value_2"}],
+          "frozen_map_time_col": [{"key": 3723456000000, "value": "time_value_2"}],
+          "frozen_map_timestamp_col": [{"key": 1718067723456, "value": "timestamp_value_2"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value_2"}],
+          "frozen_map_tinyint_col": [{"key": 6, "value": "tinyint_value_2"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371d", "value": "uuid_value_2"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key_2", "value": "varchar_value_2"}],
+          "frozen_map_varint_col": [{"key": "888888888", "value": "varint_value_2"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 2, "field_1": "tuple_key_2"}, "value": "tuple_value_2"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 2, "b": "udt_key_2"}, "value": "udt_value_2"}],
+          "frozen_set_timeuuid_col": ["81d4a031-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    return new String[] {
+      // Preimage with original values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk),
+      // Postimage with empty collections
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [],
+          "frozen_set_col": [],
+          "frozen_map_col": [],
+          "frozen_tuple_col": {"field_0": null, "field_1": null},
+          "frozen_map_ascii_col": [],
+          "frozen_map_bigint_col": [],
+          "frozen_map_boolean_col": [],
+          "frozen_map_date_col": [],
+          "frozen_map_decimal_col": [],
+          "frozen_map_double_col": [],
+          "frozen_map_float_col": [],
+          "frozen_map_int_col": [],
+          "frozen_map_inet_col": [],
+          "frozen_map_smallint_col": [],
+          "frozen_map_text_col": [],
+          "frozen_map_time_col": [],
+          "frozen_map_timestamp_col": [],
+          "frozen_map_timeuuid_col": [],
+          "frozen_map_tinyint_col": [],
+          "frozen_map_uuid_col": [],
+          "frozen_map_varchar_col": [],
+          "frozen_map_varint_col": [],
+          "frozen_map_tuple_key_col": [],
+          "frozen_map_udt_key_col": [],
+          "frozen_set_timeuuid_col": []
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    return new String[] {
+      // Preimage with original values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk),
+      // Postimage with null values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    return new String[] {
+      // Preimage with empty collections
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [],
+          "frozen_set_col": [],
+          "frozen_map_col": [],
+          "frozen_tuple_col": {"field_0": null, "field_1": null},
+          "frozen_map_ascii_col": [],
+          "frozen_map_bigint_col": [],
+          "frozen_map_boolean_col": [],
+          "frozen_map_date_col": [],
+          "frozen_map_decimal_col": [],
+          "frozen_map_double_col": [],
+          "frozen_map_float_col": [],
+          "frozen_map_int_col": [],
+          "frozen_map_inet_col": [],
+          "frozen_map_smallint_col": [],
+          "frozen_map_text_col": [],
+          "frozen_map_time_col": [],
+          "frozen_map_timestamp_col": [],
+          "frozen_map_timeuuid_col": [],
+          "frozen_map_tinyint_col": [],
+          "frozen_map_uuid_col": [],
+          "frozen_map_varchar_col": [],
+          "frozen_map_varint_col": [],
+          "frozen_map_tuple_key_col": [],
+          "frozen_map_udt_key_col": [],
+          "frozen_set_timeuuid_col": []
+        }
+        """
+          .formatted(pk),
+      // Postimage with values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    return new String[] {
+      // Preimage with null values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+          .formatted(pk),
+      // Postimage with values
+      """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+          .formatted(pk)
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsPlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesFrozenCollectionsPlainConnectorIT.java
@@ -1,0 +1,338 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesFrozenCollectionsPlainConnectorIT
+    extends ScyllaTypesFrozenCollectionsBase<String, String> {
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildPlainConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** Returns the expected key JSON for the given primary key. */
+  private String expectedKeyFor(int pk) {
+    return "{\"id\": %d}".formatted(pk);
+  }
+
+  /** Returns the full "after" JSON for an insert with values. */
+  private String afterInsertWithValues(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [1, 2, 3],
+          "frozen_set_col": ["a", "b", "c"],
+          "frozen_map_col": [{"key": 1, "value": "one"}, {"key": 2, "value": "two"}],
+          "frozen_tuple_col": {"field_0": 42, "field_1": "foo"},
+          "frozen_map_ascii_col": [{"key": "ascii_key", "value": "ascii_value"}],
+          "frozen_map_bigint_col": [{"key": 1234567890123, "value": "bigint_value"}],
+          "frozen_map_boolean_col": [{"key": true, "value": "boolean_value"}],
+          "frozen_map_date_col": [{"key": 19884, "value": "date_value"}],
+          "frozen_map_decimal_col": [{"key": "12345.67", "value": "decimal_value"}],
+          "frozen_map_double_col": [{"key": 3.14159, "value": "double_value"}],
+          "frozen_map_float_col": [{"key": 2.71828, "value": "float_value"}],
+          "frozen_map_int_col": [{"key": 42, "value": "int_value"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.1", "value": "inet_value"}],
+          "frozen_map_smallint_col": [{"key": 7, "value": "smallint_value"}],
+          "frozen_map_text_col": [{"key": "text_key", "value": "text_value"}],
+          "frozen_map_time_col": [{"key": 45296789000000, "value": "time_value"}],
+          "frozen_map_timestamp_col": [{"key": 1718022896789, "value": "timestamp_value"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value"}],
+          "frozen_map_tinyint_col": [{"key": 5, "value": "tinyint_value"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371c", "value": "uuid_value"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key", "value": "varchar_value"}],
+          "frozen_map_varint_col": [{"key": "999999999", "value": "varint_value"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 1, "field_1": "tuple_key"}, "value": "tuple_value"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 1, "b": "udt_key"}, "value": "udt_value"}],
+          "frozen_set_timeuuid_col": ["81d4a030-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the full "after" JSON for an update with new values. */
+  private String afterUpdateWithValues(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [4, 5, 6],
+          "frozen_set_col": ["x", "y", "z"],
+          "frozen_map_col": [{"key": 3, "value": "three"}, {"key": 4, "value": "four"}],
+          "frozen_tuple_col": {"field_0": 99, "field_1": "bar"},
+          "frozen_map_ascii_col": [{"key": "ascii_key_2", "value": "ascii_value_2"}],
+          "frozen_map_bigint_col": [{"key": 1234567890124, "value": "bigint_value_2"}],
+          "frozen_map_boolean_col": [{"key": false, "value": "boolean_value_2"}],
+          "frozen_map_date_col": [{"key": 19885, "value": "date_value_2"}],
+          "frozen_map_decimal_col": [{"key": "98765.43", "value": "decimal_value_2"}],
+          "frozen_map_double_col": [{"key": 2.71828, "value": "double_value_2"}],
+          "frozen_map_float_col": [{"key": 1.41421, "value": "float_value_2"}],
+          "frozen_map_int_col": [{"key": 43, "value": "int_value_2"}],
+          "frozen_map_inet_col": [{"key": "127.0.0.2", "value": "inet_value_2"}],
+          "frozen_map_smallint_col": [{"key": 8, "value": "smallint_value_2"}],
+          "frozen_map_text_col": [{"key": "text_key_2", "value": "text_value_2"}],
+          "frozen_map_time_col": [{"key": 3723456000000, "value": "time_value_2"}],
+          "frozen_map_timestamp_col": [{"key": 1718067723456, "value": "timestamp_value_2"}],
+          "frozen_map_timeuuid_col": [{"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "timeuuid_value_2"}],
+          "frozen_map_tinyint_col": [{"key": 6, "value": "tinyint_value_2"}],
+          "frozen_map_uuid_col": [{"key": "453662fa-db4b-4938-9033-d8523c0a371d", "value": "uuid_value_2"}],
+          "frozen_map_varchar_col": [{"key": "varchar_key_2", "value": "varchar_value_2"}],
+          "frozen_map_varint_col": [{"key": "888888888", "value": "varint_value_2"}],
+          "frozen_map_tuple_key_col": [{"key": {"field_0": 2, "field_1": "tuple_key_2"}, "value": "tuple_value_2"}],
+          "frozen_map_udt_key_col": [{"key": {"a": 2, "b": "udt_key_2"}, "value": "udt_value_2"}],
+          "frozen_set_timeuuid_col": ["81d4a031-4632-11f0-9484-409dd8f36eba"]
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for empty collections. */
+  private String afterEmpty(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": [],
+          "frozen_set_col": [],
+          "frozen_map_col": [],
+          "frozen_tuple_col": {"field_0": null, "field_1": null},
+          "frozen_map_ascii_col": [],
+          "frozen_map_bigint_col": [],
+          "frozen_map_boolean_col": [],
+          "frozen_map_date_col": [],
+          "frozen_map_decimal_col": [],
+          "frozen_map_double_col": [],
+          "frozen_map_float_col": [],
+          "frozen_map_int_col": [],
+          "frozen_map_inet_col": [],
+          "frozen_map_smallint_col": [],
+          "frozen_map_text_col": [],
+          "frozen_map_time_col": [],
+          "frozen_map_timestamp_col": [],
+          "frozen_map_timeuuid_col": [],
+          "frozen_map_tinyint_col": [],
+          "frozen_map_uuid_col": [],
+          "frozen_map_varchar_col": [],
+          "frozen_map_varint_col": [],
+          "frozen_map_tuple_key_col": [],
+          "frozen_map_udt_key_col": [],
+          "frozen_set_timeuuid_col": []
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for null collections (when inserting with explicit null tuple). */
+  private String afterNull(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "after" JSON for completely null collections (when inserting only pk). */
+  private String afterAllNull(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** Returns the "before" JSON for delete (all nulls except id). */
+  private String beforeDelete(int pk) {
+    return """
+        {
+          "id": %d,
+          "frozen_list_col": null,
+          "frozen_set_col": null,
+          "frozen_map_col": null,
+          "frozen_tuple_col": null,
+          "frozen_map_ascii_col": null,
+          "frozen_map_bigint_col": null,
+          "frozen_map_boolean_col": null,
+          "frozen_map_date_col": null,
+          "frozen_map_decimal_col": null,
+          "frozen_map_double_col": null,
+          "frozen_map_float_col": null,
+          "frozen_map_int_col": null,
+          "frozen_map_inet_col": null,
+          "frozen_map_smallint_col": null,
+          "frozen_map_text_col": null,
+          "frozen_map_time_col": null,
+          "frozen_map_timestamp_col": null,
+          "frozen_map_timeuuid_col": null,
+          "frozen_map_tinyint_col": null,
+          "frozen_map_uuid_col": null,
+          "frozen_map_varchar_col": null,
+          "frozen_map_varint_col": null,
+          "frozen_map_tuple_key_col": null,
+          "frozen_map_udt_key_col": null,
+          "frozen_set_timeuuid_col": null
+        }
+        """
+        .formatted(pk);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterInsertWithValues(pk), expectedKeyFor(pk))
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    return new String[] {expectedRecord("c", "null", afterEmpty(pk), expectedKeyFor(pk))};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {expectedRecord("c", "null", afterNull(pk), expectedKeyFor(pk))};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterInsertWithValues(pk), expectedKeyFor(pk)),
+      expectedRecord("d", "null", "null", expectedKeyFor(pk)),
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterInsertWithValues(pk), expectedKeyFor(pk)),
+      expectedRecord("u", afterInsertWithValues(pk), afterUpdateWithValues(pk), expectedKeyFor(pk))
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterInsertWithValues(pk), expectedKeyFor(pk)),
+      expectedRecord("u", afterInsertWithValues(pk), afterEmpty(pk), expectedKeyFor(pk))
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterInsertWithValues(pk), expectedKeyFor(pk)),
+      expectedRecord("u", afterInsertWithValues(pk), afterAllNull(pk), expectedKeyFor(pk))
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    return new String[] {
+      expectedRecord("c", "null", afterEmpty(pk), expectedKeyFor(pk)),
+      expectedRecord("u", afterEmpty(pk), afterInsertWithValues(pk), expectedKeyFor(pk))
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    // The connector populates 'before' with the post-update state for this scenario
+    return new String[] {
+      expectedRecord("c", "null", afterAllNull(pk), expectedKeyFor(pk)),
+      expectedRecord("u", afterAllNull(pk), afterInsertWithValues(pk), expectedKeyFor(pk))
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsAvroConnectorIT.java
@@ -1,0 +1,858 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildAvroConnector;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesNonFrozenCollectionsAvroConnectorIT
+    extends ScyllaTypesNonFrozenCollectionsBase<GenericRecord, GenericRecord> {
+
+  // Expected map values for insert/update tests with all columns populated
+  private static final String MAP_ASCII_COL_VALUE =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key\", \"value\": \"ascii_value\"}]";
+  private static final String MAP_BIGINT_COL_VALUE =
+      "\"map_bigint_col\": [{\"key\": 1234567890123, \"value\": \"bigint_value\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE =
+      "\"map_boolean_col\": [{\"key\": true, \"value\": \"boolean_value\"}]";
+  private static final String MAP_DATE_COL_VALUE =
+      "\"map_date_col\": [{\"key\": 19884, \"value\": \"date_value\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE =
+      "\"map_decimal_col\": [{\"key\": \"12345.67\", \"value\": \"decimal_value\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE =
+      "\"map_double_col\": [{\"key\": 3.14159, \"value\": \"double_value\"}]";
+  private static final String MAP_FLOAT_COL_VALUE =
+      "\"map_float_col\": [{\"key\": 2.71828, \"value\": \"float_value\"}]";
+  private static final String MAP_INET_COL_VALUE =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.1\", \"value\": \"inet_value\"}]";
+  private static final String MAP_INT_COL_VALUE =
+      "\"map_int_col\": [{\"key\": 42, \"value\": \"int_value\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE =
+      "\"map_smallint_col\": [{\"key\": 7, \"value\": \"smallint_value\"}]";
+  private static final String MAP_TEXT_COL_VALUE =
+      "\"map_text_col\": [{\"key\": \"text_key\", \"value\": \"text_value\"}]";
+  private static final String MAP_TIME_COL_VALUE =
+      "\"map_time_col\": [{\"key\": 45296789000000, \"value\": \"time_value\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE =
+      "\"map_timestamp_col\": [{\"key\": 1718022896789, \"value\": \"timestamp_value\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a030-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value\"}]";
+  private static final String MAP_TINYINT_COL_VALUE =
+      "\"map_tinyint_col\": [{\"key\": 5, \"value\": \"tinyint_value\"}]";
+  private static final String MAP_UUID_COL_VALUE =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371c\", \"value\": \"uuid_value\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key\", \"value\": \"varchar_value\"}]";
+  private static final String MAP_VARINT_COL_VALUE =
+      "\"map_varint_col\": [{\"key\": \"999999999\", \"value\": \"varint_value\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE =
+      "\"set_timeuuid_col\": [\"81d4a030-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Expected map values for update tests (different values)
+  private static final String MAP_ASCII_COL_VALUE_2 =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key_2\", \"value\": \"ascii_value_2\"}]";
+  private static final String MAP_BIGINT_COL_VALUE_2 =
+      "\"map_bigint_col\": [{\"key\": 1234567890124, \"value\": \"bigint_value_2\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE_2 =
+      "\"map_boolean_col\": [{\"key\": false, \"value\": \"boolean_value_2\"}]";
+  private static final String MAP_DATE_COL_VALUE_2 =
+      "\"map_date_col\": [{\"key\": 19885, \"value\": \"date_value_2\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE_2 =
+      "\"map_decimal_col\": [{\"key\": \"98765.43\", \"value\": \"decimal_value_2\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE_2 =
+      "\"map_double_col\": [{\"key\": 2.71828, \"value\": \"double_value_2\"}]";
+  private static final String MAP_FLOAT_COL_VALUE_2 =
+      "\"map_float_col\": [{\"key\": 1.41421, \"value\": \"float_value_2\"}]";
+  private static final String MAP_INET_COL_VALUE_2 =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.2\", \"value\": \"inet_value_2\"}]";
+  private static final String MAP_INT_COL_VALUE_2 =
+      "\"map_int_col\": [{\"key\": 43, \"value\": \"int_value_2\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE_2 =
+      "\"map_smallint_col\": [{\"key\": 8, \"value\": \"smallint_value_2\"}]";
+  private static final String MAP_TEXT_COL_VALUE_2 =
+      "\"map_text_col\": [{\"key\": \"text_key_2\", \"value\": \"text_value_2\"}]";
+  private static final String MAP_TIME_COL_VALUE_2 =
+      "\"map_time_col\": [{\"key\": 3723456000000, \"value\": \"time_value_2\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE_2 =
+      "\"map_timestamp_col\": [{\"key\": 1718067723456, \"value\": \"timestamp_value_2\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE_2 =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a031-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value_2\"}]";
+  private static final String MAP_TINYINT_COL_VALUE_2 =
+      "\"map_tinyint_col\": [{\"key\": 6, \"value\": \"tinyint_value_2\"}]";
+  private static final String MAP_UUID_COL_VALUE_2 =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371d\", \"value\": \"uuid_value_2\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE_2 =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key_2\", \"value\": \"varchar_value_2\"}]";
+  private static final String MAP_VARINT_COL_VALUE_2 =
+      "\"map_varint_col\": [{\"key\": \"888888888\", \"value\": \"varint_value_2\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE_2 =
+      "\"set_timeuuid_col\": [\"81d4a031-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Null values for all extra columns
+  private static final String ALL_EXTRA_COLS_NULL =
+      "\"map_ascii_col\": null, \"map_bigint_col\": null, \"map_boolean_col\": null, "
+          + "\"map_date_col\": null, \"map_decimal_col\": null, \"map_double_col\": null, "
+          + "\"map_float_col\": null, \"map_inet_col\": null, \"map_int_col\": null, "
+          + "\"map_smallint_col\": null, \"map_text_col\": null, \"map_time_col\": null, "
+          + "\"map_timestamp_col\": null, \"map_timeuuid_col\": null, \"map_tinyint_col\": null, "
+          + "\"map_uuid_col\": null, \"map_varchar_col\": null, \"map_varint_col\": null, "
+          + "\"set_timeuuid_col\": null";
+
+  // All extra columns with initial values
+  private static final String ALL_EXTRA_COLS_VALUES =
+      MAP_ASCII_COL_VALUE
+          + ", "
+          + MAP_BIGINT_COL_VALUE
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE
+          + ", "
+          + MAP_DATE_COL_VALUE
+          + ", "
+          + MAP_DECIMAL_COL_VALUE
+          + ", "
+          + MAP_DOUBLE_COL_VALUE
+          + ", "
+          + MAP_FLOAT_COL_VALUE
+          + ", "
+          + MAP_INET_COL_VALUE
+          + ", "
+          + MAP_INT_COL_VALUE
+          + ", "
+          + MAP_SMALLINT_COL_VALUE
+          + ", "
+          + MAP_TEXT_COL_VALUE
+          + ", "
+          + MAP_TIME_COL_VALUE
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE
+          + ", "
+          + MAP_TINYINT_COL_VALUE
+          + ", "
+          + MAP_UUID_COL_VALUE
+          + ", "
+          + MAP_VARCHAR_COL_VALUE
+          + ", "
+          + MAP_VARINT_COL_VALUE
+          + ", "
+          + SET_TIMEUUID_COL_VALUE;
+
+  // All extra columns with updated values
+  private static final String ALL_EXTRA_COLS_VALUES_2 =
+      MAP_ASCII_COL_VALUE_2
+          + ", "
+          + MAP_BIGINT_COL_VALUE_2
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE_2
+          + ", "
+          + MAP_DATE_COL_VALUE_2
+          + ", "
+          + MAP_DECIMAL_COL_VALUE_2
+          + ", "
+          + MAP_DOUBLE_COL_VALUE_2
+          + ", "
+          + MAP_FLOAT_COL_VALUE_2
+          + ", "
+          + MAP_INET_COL_VALUE_2
+          + ", "
+          + MAP_INT_COL_VALUE_2
+          + ", "
+          + MAP_SMALLINT_COL_VALUE_2
+          + ", "
+          + MAP_TEXT_COL_VALUE_2
+          + ", "
+          + MAP_TIME_COL_VALUE_2
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE_2
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE_2
+          + ", "
+          + MAP_TINYINT_COL_VALUE_2
+          + ", "
+          + MAP_UUID_COL_VALUE_2
+          + ", "
+          + MAP_VARCHAR_COL_VALUE_2
+          + ", "
+          + MAP_VARINT_COL_VALUE_2
+          + ", "
+          + SET_TIMEUUID_COL_VALUE_2;
+
+  @BeforeAll
+  @Override
+  public void setupSuite(TestInfo testInfo) {
+    Assumptions.assumeTrue(
+        KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
+    Assumptions.assumeTrue(
+        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
+        "Avro tests require distributed mode, otherwise Avro converter is not available");
+    super.setupSuite(testInfo);
+  }
+
+  @Override
+  KafkaConsumer<GenericRecord, GenericRecord> buildConsumer(
+      String connectorName, String tableName) {
+    return buildAvroConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(GenericRecord value) {
+    return extractIdFromKeyField(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(GenericRecord key) {
+    return extractIdFromRecord(key);
+  }
+
+  private int extractIdFromKeyField(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "key" field first (payload-key)
+    if (record.getSchema().getField("key") != null) {
+      Object key = record.get("key");
+      if (key instanceof GenericRecord) {
+        GenericRecord keyRecord = (GenericRecord) key;
+        if (keyRecord.getSchema().getField("id") != null) {
+          Object id = keyRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to after/before/direct for backwards compatibility
+    return extractIdFromRecord(record);
+  }
+
+  private int extractIdFromRecord(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "after" field first (standard Debezium envelope)
+    if (record.getSchema().getField("after") != null) {
+      Object after = record.get("after");
+      if (after instanceof GenericRecord) {
+        GenericRecord afterRecord = (GenericRecord) after;
+        if (afterRecord.getSchema().getField("id") != null) {
+          Object id = afterRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Try "before" field (for delete operations)
+    if (record.getSchema().getField("before") != null) {
+      Object before = record.get("before");
+      if (before instanceof GenericRecord) {
+        GenericRecord beforeRecord = (GenericRecord) before;
+        if (beforeRecord.getSchema().getField("id") != null) {
+          Object id = beforeRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to direct "id" field (for keys)
+    if (record.getSchema().getField("id") != null) {
+      Object id = record.get("id");
+      if (id instanceof Number) {
+        return ((Number) id).intValue();
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10],
+            "set_col": ["x"],
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // DELETE record
+      """
+        {
+          "before": null,
+          "after": null,
+          "key": {"id": %d},
+          "op": "d",
+          "source": %s
+        }
+        """
+          .formatted(pk, expectedSource()),
+      // Tombstone
+      null
+    };
+  }
+
+  @Override
+  String[] expectedUpdateListAddElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateSetAddElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y"],
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateMapAddElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateListRemoveElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateSetRemoveElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateMapRemoveElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [40, 50, 60],
+            "set_col": ["a", "b", "c"],
+            "map_col": [{"key": 30, "value": "thirty"}, {"key": 40, "value": "forty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_VALUES_2, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record - empty collections become null in Scylla
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    // Empty collections are stored as null in Scylla, so this is similar to null-to-value
+    return new String[] {
+      // INSERT record - empty collections become null
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsBase.java
@@ -1,0 +1,446 @@
+package com.scylladb.cdc.debezium.connector;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for non-frozen collections replication. Tests insert, update, and delete
+ * operations with non-frozen collections (list, set, map).
+ *
+ * <p>Each test uses a unique primary key (obtained via {@link #reservePk()}) for isolation,
+ * allowing all tests to share a single connector and table.
+ *
+ * <p>Non-frozen collections differ from frozen collections in that they support element-level
+ * operations (add/remove individual elements) rather than only whole-collection replacement.
+ * However, non-frozen maps cannot have UDTs or tuples as keys (only scalar types are allowed).
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
+public abstract class ScyllaTypesNonFrozenCollectionsBase<K, V> extends ScyllaTypesIT<K, V> {
+
+  // Column names for inserts - includes all non-frozen collection columns with various key types
+  private static final String INSERT_COLUMNS =
+      "id, list_col, set_col, map_col, "
+          + "map_ascii_col, map_bigint_col, map_boolean_col, "
+          + "map_date_col, map_decimal_col, map_double_col, "
+          + "map_float_col, map_int_col, map_inet_col, "
+          + "map_smallint_col, map_text_col, map_time_col, "
+          + "map_timestamp_col, map_timeuuid_col, map_tinyint_col, "
+          + "map_uuid_col, map_varchar_col, map_varint_col, "
+          + "set_timeuuid_col";
+
+  private static String valuesWithValues(int pk) {
+    return pk
+        + ", [10, 20, 30], {'x', 'y', 'z'}, {10: 'ten', 20: 'twenty'}, "
+        + "{'ascii_key': 'ascii_value'}, {1234567890123: 'bigint_value'}, "
+        + "{true: 'boolean_value'}, {'2024-06-10': 'date_value'}, "
+        + "{12345.67: 'decimal_value'}, {3.14159: 'double_value'}, "
+        + "{2.71828: 'float_value'}, {42: 'int_value'}, "
+        + "{'127.0.0.1': 'inet_value'}, {7: 'smallint_value'}, "
+        + "{'text_key': 'text_value'}, {'12:34:56.789': 'time_value'}, "
+        + "{'2024-06-10T12:34:56.789Z': 'timestamp_value'}, "
+        + "{81d4a030-4632-11f0-9484-409dd8f36eba: 'timeuuid_value'}, "
+        + "{5: 'tinyint_value'}, {453662fa-db4b-4938-9033-d8523c0a371c: 'uuid_value'}, "
+        + "{'varchar_key': 'varchar_value'}, {999999999: 'varint_value'}, "
+        + "{81d4a030-4632-11f0-9484-409dd8f36eba}";
+  }
+
+  private static String valuesWithNull(int pk) {
+    return pk
+        + ", null, null, null, "
+        + "null, null, null, null, null, null, null, null, null, null, null, null, "
+        + "null, null, null, null, null, null, null";
+  }
+
+  private static String valuesWithEmpty(int pk) {
+    return pk
+        + ", [], {}, {}, "
+        + "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "
+        + "{}, {}, {}, {}, {}, {}, {}";
+  }
+
+  private static final String UPDATE_SET_VALUES =
+      "list_col = [40, 50, 60], set_col = {'a', 'b', 'c'}, "
+          + "map_col = {30: 'thirty', 40: 'forty'}, "
+          + "map_ascii_col = {'ascii_key_2': 'ascii_value_2'}, "
+          + "map_bigint_col = {1234567890124: 'bigint_value_2'}, "
+          + "map_boolean_col = {false: 'boolean_value_2'}, "
+          + "map_date_col = {'2024-06-11': 'date_value_2'}, "
+          + "map_decimal_col = {98765.43: 'decimal_value_2'}, "
+          + "map_double_col = {2.71828: 'double_value_2'}, "
+          + "map_float_col = {1.41421: 'float_value_2'}, "
+          + "map_int_col = {43: 'int_value_2'}, "
+          + "map_inet_col = {'127.0.0.2': 'inet_value_2'}, "
+          + "map_smallint_col = {8: 'smallint_value_2'}, "
+          + "map_text_col = {'text_key_2': 'text_value_2'}, "
+          + "map_time_col = {'01:02:03.456': 'time_value_2'}, "
+          + "map_timestamp_col = {'2024-06-11T01:02:03.456Z': 'timestamp_value_2'}, "
+          + "map_timeuuid_col = {81d4a031-4632-11f0-9484-409dd8f36eba: 'timeuuid_value_2'}, "
+          + "map_tinyint_col = {6: 'tinyint_value_2'}, "
+          + "map_uuid_col = {453662fa-db4b-4938-9033-d8523c0a371d: 'uuid_value_2'}, "
+          + "map_varchar_col = {'varchar_key_2': 'varchar_value_2'}, "
+          + "map_varint_col = {888888888: 'varint_value_2'}, "
+          + "set_timeuuid_col = {81d4a031-4632-11f0-9484-409dd8f36eba}";
+
+  private static final String UPDATE_SET_INITIAL_VALUES =
+      "list_col = [10, 20, 30], set_col = {'x', 'y', 'z'}, "
+          + "map_col = {10: 'ten', 20: 'twenty'}, "
+          + "map_ascii_col = {'ascii_key': 'ascii_value'}, "
+          + "map_bigint_col = {1234567890123: 'bigint_value'}, "
+          + "map_boolean_col = {true: 'boolean_value'}, "
+          + "map_date_col = {'2024-06-10': 'date_value'}, "
+          + "map_decimal_col = {12345.67: 'decimal_value'}, "
+          + "map_double_col = {3.14159: 'double_value'}, "
+          + "map_float_col = {2.71828: 'float_value'}, "
+          + "map_int_col = {42: 'int_value'}, "
+          + "map_inet_col = {'127.0.0.1': 'inet_value'}, "
+          + "map_smallint_col = {7: 'smallint_value'}, "
+          + "map_text_col = {'text_key': 'text_value'}, "
+          + "map_time_col = {'12:34:56.789': 'time_value'}, "
+          + "map_timestamp_col = {'2024-06-10T12:34:56.789Z': 'timestamp_value'}, "
+          + "map_timeuuid_col = {81d4a030-4632-11f0-9484-409dd8f36eba: 'timeuuid_value'}, "
+          + "map_tinyint_col = {5: 'tinyint_value'}, "
+          + "map_uuid_col = {453662fa-db4b-4938-9033-d8523c0a371c: 'uuid_value'}, "
+          + "map_varchar_col = {'varchar_key': 'varchar_value'}, "
+          + "map_varint_col = {999999999: 'varint_value'}, "
+          + "set_timeuuid_col = {81d4a030-4632-11f0-9484-409dd8f36eba}";
+
+  private static final String UPDATE_SET_EMPTY =
+      "list_col = [], set_col = {}, "
+          + "map_col = {}, "
+          + "map_ascii_col = {}, map_bigint_col = {}, "
+          + "map_boolean_col = {}, map_date_col = {}, "
+          + "map_decimal_col = {}, map_double_col = {}, "
+          + "map_float_col = {}, map_int_col = {}, "
+          + "map_inet_col = {}, map_smallint_col = {}, "
+          + "map_text_col = {}, map_time_col = {}, "
+          + "map_timestamp_col = {}, map_timeuuid_col = {}, "
+          + "map_tinyint_col = {}, map_uuid_col = {}, "
+          + "map_varchar_col = {}, map_varint_col = {}, "
+          + "set_timeuuid_col = {}";
+
+  private static final String UPDATE_SET_NULL =
+      "list_col = null, set_col = null, "
+          + "map_col = null, "
+          + "map_ascii_col = null, map_bigint_col = null, "
+          + "map_boolean_col = null, map_date_col = null, "
+          + "map_decimal_col = null, map_double_col = null, "
+          + "map_float_col = null, map_int_col = null, "
+          + "map_inet_col = null, map_smallint_col = null, "
+          + "map_text_col = null, map_time_col = null, "
+          + "map_timestamp_col = null, map_timeuuid_col = null, "
+          + "map_tinyint_col = null, map_uuid_col = null, "
+          + "map_varchar_col = null, map_varint_col = null, "
+          + "set_timeuuid_col = null";
+
+  /** Returns expected records for an INSERT with all collection values present. */
+  abstract String[] expectedInsertWithValues(int pk);
+
+  /** Returns expected records for an INSERT with all collection values set to null. */
+  abstract String[] expectedInsertWithNull(int pk);
+
+  /** Returns expected records for a DELETE of the row. */
+  abstract String[] expectedDelete(int pk);
+
+  /** Returns expected records for adding an element to a list column. */
+  abstract String[] expectedUpdateListAddElement(int pk);
+
+  /** Returns expected records for adding an element to a set column. */
+  abstract String[] expectedUpdateSetAddElement(int pk);
+
+  /** Returns expected records for adding an entry to a map column. */
+  abstract String[] expectedUpdateMapAddElement(int pk);
+
+  /** Returns expected records for removing an element from a list column. */
+  abstract String[] expectedUpdateListRemoveElement(int pk);
+
+  /** Returns expected records for removing an element from a set column. */
+  abstract String[] expectedUpdateSetRemoveElement(int pk);
+
+  /** Returns expected records for removing an entry from a map column. */
+  abstract String[] expectedUpdateMapRemoveElement(int pk);
+
+  /** Returns expected records for replacing entire collections with new values. */
+  abstract String[] expectedUpdateFromValueToValue(int pk);
+
+  /** Returns expected records for setting collections to null from populated values. */
+  abstract String[] expectedUpdateFromValueToNull(int pk);
+
+  /** Returns expected records for setting collections to empty from populated values. */
+  abstract String[] expectedUpdateFromValueToEmpty(int pk);
+
+  /** Returns expected records for updating collections from null to populated values. */
+  abstract String[] expectedUpdateFromNullToValue(int pk);
+
+  /** Returns expected records for updating collections from empty to populated values. */
+  abstract String[] expectedUpdateFromEmptyToValue(int pk);
+
+  @Override
+  protected String createTableCql(String tableName) {
+    // Non-frozen collections with various key types.
+    // Note: Unlike frozen collections, non-frozen maps cannot have UDTs or tuples as keys.
+    return "("
+        + "id int PRIMARY KEY,"
+        + "list_col list<int>,"
+        + "set_col set<text>,"
+        + "map_col map<int, text>,"
+        + "map_ascii_col map<ascii, text>,"
+        + "map_bigint_col map<bigint, text>,"
+        + "map_boolean_col map<boolean, text>,"
+        + "map_date_col map<date, text>,"
+        + "map_decimal_col map<decimal, text>,"
+        + "map_double_col map<double, text>,"
+        + "map_float_col map<float, text>,"
+        + "map_int_col map<int, text>,"
+        + "map_inet_col map<inet, text>,"
+        + "map_smallint_col map<smallint, text>,"
+        + "map_text_col map<text, text>,"
+        + "map_time_col map<time, text>,"
+        + "map_timestamp_col map<timestamp, text>,"
+        + "map_timeuuid_col map<timeuuid, text>,"
+        + "map_tinyint_col map<tinyint, text>,"
+        + "map_uuid_col map<uuid, text>,"
+        + "map_varchar_col map<varchar, text>,"
+        + "map_varint_col map<varint, text>,"
+        + "set_timeuuid_col set<timeuuid>"
+        + ")";
+  }
+
+  // ===================== CQL Helper Methods =====================
+
+  /** Inserts a row with all collection values. */
+  protected void insertWithValues(int pk) {
+    session.execute(
+        "INSERT INTO %s (%s) VALUES (%s)"
+            .formatted(getSuiteKeyspaceTableName(), INSERT_COLUMNS, valuesWithValues(pk)));
+  }
+
+  /** Inserts a row with null collection values. */
+  protected void insertWithNull(int pk) {
+    session.execute(
+        "INSERT INTO %s (%s) VALUES (%s)"
+            .formatted(getSuiteKeyspaceTableName(), INSERT_COLUMNS, valuesWithNull(pk)));
+  }
+
+  /** Inserts a row with empty collection values. */
+  protected void insertWithEmpty(int pk) {
+    session.execute(
+        "INSERT INTO %s (%s) VALUES (%s)"
+            .formatted(getSuiteKeyspaceTableName(), INSERT_COLUMNS, valuesWithEmpty(pk)));
+  }
+
+  /** Inserts a row with minimal collection values (for delete/update tests). */
+  protected void insertMinimal(int pk) {
+    session.execute(
+        "INSERT INTO %s (id, list_col, set_col, map_col) VALUES (%d, [10], {'x'}, {10: 'ten'})"
+            .formatted(getSuiteKeyspaceTableName(), pk));
+  }
+
+  /** Inserts a row with only list column. */
+  protected void insertListOnly(int pk, String listValue) {
+    session.execute(
+        "INSERT INTO %s (id, list_col) VALUES (%d, %s)"
+            .formatted(getSuiteKeyspaceTableName(), pk, listValue));
+  }
+
+  /** Inserts a row with only set column. */
+  protected void insertSetOnly(int pk, String setValue) {
+    session.execute(
+        "INSERT INTO %s (id, set_col) VALUES (%d, %s)"
+            .formatted(getSuiteKeyspaceTableName(), pk, setValue));
+  }
+
+  /** Inserts a row with only map column. */
+  protected void insertMapOnly(int pk, String mapValue) {
+    session.execute(
+        "INSERT INTO %s (id, map_col) VALUES (%d, %s)"
+            .formatted(getSuiteKeyspaceTableName(), pk, mapValue));
+  }
+
+  /** Deletes a row by primary key. */
+  protected void deleteRow(int pk) {
+    session.execute("DELETE FROM %s WHERE id = %d".formatted(getSuiteKeyspaceTableName(), pk));
+  }
+
+  /** Appends elements to list column. */
+  protected void updateListAppend(int pk, String elements) {
+    session.execute(
+        "UPDATE %s SET list_col = list_col + %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), elements, pk));
+  }
+
+  /** Removes elements from list column. */
+  protected void updateListRemove(int pk, String elements) {
+    session.execute(
+        "UPDATE %s SET list_col = list_col - %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), elements, pk));
+  }
+
+  /** Adds elements to set column. */
+  protected void updateSetAdd(int pk, String elements) {
+    session.execute(
+        "UPDATE %s SET set_col = set_col + %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), elements, pk));
+  }
+
+  /** Removes elements from set column. */
+  protected void updateSetRemove(int pk, String elements) {
+    session.execute(
+        "UPDATE %s SET set_col = set_col - %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), elements, pk));
+  }
+
+  /** Adds entries to map column. */
+  protected void updateMapAdd(int pk, String entries) {
+    session.execute(
+        "UPDATE %s SET map_col = map_col + %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), entries, pk));
+  }
+
+  /** Removes keys from map column. */
+  protected void updateMapRemove(int pk, String keys) {
+    session.execute(
+        "UPDATE %s SET map_col = map_col - %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), keys, pk));
+  }
+
+  /** Updates all collection columns to new values (whole-collection replacement). */
+  protected void updateToValues(int pk) {
+    session.execute(
+        "UPDATE %s SET %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), UPDATE_SET_VALUES, pk));
+  }
+
+  /** Updates all collection columns to initial values (for testing empty/null to value). */
+  protected void updateToInitialValues(int pk) {
+    session.execute(
+        "UPDATE %s SET %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), UPDATE_SET_INITIAL_VALUES, pk));
+  }
+
+  /** Updates all collection columns to null. */
+  protected void updateToNull(int pk) {
+    session.execute(
+        "UPDATE %s SET %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), UPDATE_SET_NULL, pk));
+  }
+
+  /** Updates all collection columns to empty collections. */
+  protected void updateToEmpty(int pk) {
+    session.execute(
+        "UPDATE %s SET %s WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), UPDATE_SET_EMPTY, pk));
+  }
+
+  // ===================== Test Methods =====================
+
+  @Test
+  void testInsertWithValues() {
+    int pk = reservePk();
+    insertWithValues(pk);
+    waitAndAssert(pk, expectedInsertWithValues(pk));
+  }
+
+  @Test
+  void testInsertWithNull() {
+    int pk = reservePk();
+    insertWithNull(pk);
+    waitAndAssert(pk, expectedInsertWithNull(pk));
+  }
+
+  @Test
+  void testDelete() {
+    int pk = reservePk();
+    insertMinimal(pk);
+    deleteRow(pk);
+    waitAndAssert(pk, expectedDelete(pk));
+  }
+
+  @Test
+  void testUpdateListAddElement() {
+    int pk = reservePk();
+    insertListOnly(pk, "[10, 20]");
+    updateListAppend(pk, "[30]");
+    waitAndAssert(pk, expectedUpdateListAddElement(pk));
+  }
+
+  @Test
+  void testUpdateSetAddElement() {
+    int pk = reservePk();
+    insertSetOnly(pk, "{'x', 'y'}");
+    updateSetAdd(pk, "{'z'}");
+    waitAndAssert(pk, expectedUpdateSetAddElement(pk));
+  }
+
+  @Test
+  void testUpdateMapAddElement() {
+    int pk = reservePk();
+    insertMapOnly(pk, "{10: 'ten'}");
+    updateMapAdd(pk, "{20: 'twenty'}");
+    waitAndAssert(pk, expectedUpdateMapAddElement(pk));
+  }
+
+  @Test
+  void testUpdateListRemoveElement() {
+    int pk = reservePk();
+    insertListOnly(pk, "[10, 20, 30]");
+    updateListRemove(pk, "[20]");
+    waitAndAssert(pk, expectedUpdateListRemoveElement(pk));
+  }
+
+  @Test
+  void testUpdateSetRemoveElement() {
+    int pk = reservePk();
+    insertSetOnly(pk, "{'x', 'y', 'z'}");
+    updateSetRemove(pk, "{'y'}");
+    waitAndAssert(pk, expectedUpdateSetRemoveElement(pk));
+  }
+
+  @Test
+  void testUpdateMapRemoveElement() {
+    int pk = reservePk();
+    insertMapOnly(pk, "{10: 'ten', 20: 'twenty'}");
+    updateMapRemove(pk, "{10}");
+    waitAndAssert(pk, expectedUpdateMapRemoveElement(pk));
+  }
+
+  @Test
+  void testUpdateFromValueToValue() {
+    int pk = reservePk();
+    insertWithValues(pk);
+    updateToValues(pk);
+    waitAndAssert(pk, expectedUpdateFromValueToValue(pk));
+  }
+
+  @Test
+  void testUpdateFromValueToNull() {
+    int pk = reservePk();
+    insertWithValues(pk);
+    updateToNull(pk);
+    waitAndAssert(pk, expectedUpdateFromValueToNull(pk));
+  }
+
+  @Test
+  void testUpdateFromValueToEmpty() {
+    int pk = reservePk();
+    insertWithValues(pk);
+    updateToEmpty(pk);
+    waitAndAssert(pk, expectedUpdateFromValueToEmpty(pk));
+  }
+
+  @Test
+  void testUpdateFromNullToValue() {
+    int pk = reservePk();
+    insertWithNull(pk);
+    updateToInitialValues(pk);
+    waitAndAssert(pk, expectedUpdateFromNullToValue(pk));
+  }
+
+  @Test
+  void testUpdateFromEmptyToValue() {
+    int pk = reservePk();
+    insertWithEmpty(pk);
+    updateToInitialValues(pk);
+    waitAndAssert(pk, expectedUpdateFromEmptyToValue(pk));
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsNewRecordStateConnectorIT.java
@@ -1,0 +1,593 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildScyllaExtractNewRecordStateConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesNonFrozenCollectionsNewRecordStateConnectorIT
+    extends ScyllaTypesNonFrozenCollectionsBase<String, String> {
+
+  // Expected map values for insert/update tests with all columns populated
+  private static final String MAP_ASCII_COL_VALUE =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key\", \"value\": \"ascii_value\"}]";
+  private static final String MAP_BIGINT_COL_VALUE =
+      "\"map_bigint_col\": [{\"key\": 1234567890123, \"value\": \"bigint_value\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE =
+      "\"map_boolean_col\": [{\"key\": true, \"value\": \"boolean_value\"}]";
+  private static final String MAP_DATE_COL_VALUE =
+      "\"map_date_col\": [{\"key\": 19884, \"value\": \"date_value\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE =
+      "\"map_decimal_col\": [{\"key\": \"12345.67\", \"value\": \"decimal_value\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE =
+      "\"map_double_col\": [{\"key\": 3.14159, \"value\": \"double_value\"}]";
+  private static final String MAP_FLOAT_COL_VALUE =
+      "\"map_float_col\": [{\"key\": 2.71828, \"value\": \"float_value\"}]";
+  private static final String MAP_INET_COL_VALUE =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.1\", \"value\": \"inet_value\"}]";
+  private static final String MAP_INT_COL_VALUE =
+      "\"map_int_col\": [{\"key\": 42, \"value\": \"int_value\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE =
+      "\"map_smallint_col\": [{\"key\": 7, \"value\": \"smallint_value\"}]";
+  private static final String MAP_TEXT_COL_VALUE =
+      "\"map_text_col\": [{\"key\": \"text_key\", \"value\": \"text_value\"}]";
+  private static final String MAP_TIME_COL_VALUE =
+      "\"map_time_col\": [{\"key\": 45296789000000, \"value\": \"time_value\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE =
+      "\"map_timestamp_col\": [{\"key\": 1718022896789, \"value\": \"timestamp_value\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a030-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value\"}]";
+  private static final String MAP_TINYINT_COL_VALUE =
+      "\"map_tinyint_col\": [{\"key\": 5, \"value\": \"tinyint_value\"}]";
+  private static final String MAP_UUID_COL_VALUE =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371c\", \"value\": \"uuid_value\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key\", \"value\": \"varchar_value\"}]";
+  private static final String MAP_VARINT_COL_VALUE =
+      "\"map_varint_col\": [{\"key\": \"999999999\", \"value\": \"varint_value\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE =
+      "\"set_timeuuid_col\": [\"81d4a030-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Expected map values for update tests (different values)
+  private static final String MAP_ASCII_COL_VALUE_2 =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key_2\", \"value\": \"ascii_value_2\"}]";
+  private static final String MAP_BIGINT_COL_VALUE_2 =
+      "\"map_bigint_col\": [{\"key\": 1234567890124, \"value\": \"bigint_value_2\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE_2 =
+      "\"map_boolean_col\": [{\"key\": false, \"value\": \"boolean_value_2\"}]";
+  private static final String MAP_DATE_COL_VALUE_2 =
+      "\"map_date_col\": [{\"key\": 19885, \"value\": \"date_value_2\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE_2 =
+      "\"map_decimal_col\": [{\"key\": \"98765.43\", \"value\": \"decimal_value_2\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE_2 =
+      "\"map_double_col\": [{\"key\": 2.71828, \"value\": \"double_value_2\"}]";
+  private static final String MAP_FLOAT_COL_VALUE_2 =
+      "\"map_float_col\": [{\"key\": 1.41421, \"value\": \"float_value_2\"}]";
+  private static final String MAP_INET_COL_VALUE_2 =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.2\", \"value\": \"inet_value_2\"}]";
+  private static final String MAP_INT_COL_VALUE_2 =
+      "\"map_int_col\": [{\"key\": 43, \"value\": \"int_value_2\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE_2 =
+      "\"map_smallint_col\": [{\"key\": 8, \"value\": \"smallint_value_2\"}]";
+  private static final String MAP_TEXT_COL_VALUE_2 =
+      "\"map_text_col\": [{\"key\": \"text_key_2\", \"value\": \"text_value_2\"}]";
+  private static final String MAP_TIME_COL_VALUE_2 =
+      "\"map_time_col\": [{\"key\": 3723456000000, \"value\": \"time_value_2\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE_2 =
+      "\"map_timestamp_col\": [{\"key\": 1718067723456, \"value\": \"timestamp_value_2\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE_2 =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a031-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value_2\"}]";
+  private static final String MAP_TINYINT_COL_VALUE_2 =
+      "\"map_tinyint_col\": [{\"key\": 6, \"value\": \"tinyint_value_2\"}]";
+  private static final String MAP_UUID_COL_VALUE_2 =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371d\", \"value\": \"uuid_value_2\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE_2 =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key_2\", \"value\": \"varchar_value_2\"}]";
+  private static final String MAP_VARINT_COL_VALUE_2 =
+      "\"map_varint_col\": [{\"key\": \"888888888\", \"value\": \"varint_value_2\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE_2 =
+      "\"set_timeuuid_col\": [\"81d4a031-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Null values for all extra columns
+  private static final String ALL_EXTRA_COLS_NULL =
+      "\"map_ascii_col\": null, \"map_bigint_col\": null, \"map_boolean_col\": null, "
+          + "\"map_date_col\": null, \"map_decimal_col\": null, \"map_double_col\": null, "
+          + "\"map_float_col\": null, \"map_inet_col\": null, \"map_int_col\": null, "
+          + "\"map_smallint_col\": null, \"map_text_col\": null, \"map_time_col\": null, "
+          + "\"map_timestamp_col\": null, \"map_timeuuid_col\": null, \"map_tinyint_col\": null, "
+          + "\"map_uuid_col\": null, \"map_varchar_col\": null, \"map_varint_col\": null, "
+          + "\"set_timeuuid_col\": null";
+
+  // All extra columns with initial values
+  private static final String ALL_EXTRA_COLS_VALUES =
+      MAP_ASCII_COL_VALUE
+          + ", "
+          + MAP_BIGINT_COL_VALUE
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE
+          + ", "
+          + MAP_DATE_COL_VALUE
+          + ", "
+          + MAP_DECIMAL_COL_VALUE
+          + ", "
+          + MAP_DOUBLE_COL_VALUE
+          + ", "
+          + MAP_FLOAT_COL_VALUE
+          + ", "
+          + MAP_INET_COL_VALUE
+          + ", "
+          + MAP_INT_COL_VALUE
+          + ", "
+          + MAP_SMALLINT_COL_VALUE
+          + ", "
+          + MAP_TEXT_COL_VALUE
+          + ", "
+          + MAP_TIME_COL_VALUE
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE
+          + ", "
+          + MAP_TINYINT_COL_VALUE
+          + ", "
+          + MAP_UUID_COL_VALUE
+          + ", "
+          + MAP_VARCHAR_COL_VALUE
+          + ", "
+          + MAP_VARINT_COL_VALUE
+          + ", "
+          + SET_TIMEUUID_COL_VALUE;
+
+  // All extra columns with updated values
+  private static final String ALL_EXTRA_COLS_VALUES_2 =
+      MAP_ASCII_COL_VALUE_2
+          + ", "
+          + MAP_BIGINT_COL_VALUE_2
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE_2
+          + ", "
+          + MAP_DATE_COL_VALUE_2
+          + ", "
+          + MAP_DECIMAL_COL_VALUE_2
+          + ", "
+          + MAP_DOUBLE_COL_VALUE_2
+          + ", "
+          + MAP_FLOAT_COL_VALUE_2
+          + ", "
+          + MAP_INET_COL_VALUE_2
+          + ", "
+          + MAP_INT_COL_VALUE_2
+          + ", "
+          + MAP_SMALLINT_COL_VALUE_2
+          + ", "
+          + MAP_TEXT_COL_VALUE_2
+          + ", "
+          + MAP_TIME_COL_VALUE_2
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE_2
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE_2
+          + ", "
+          + MAP_TINYINT_COL_VALUE_2
+          + ", "
+          + MAP_UUID_COL_VALUE_2
+          + ", "
+          + MAP_VARCHAR_COL_VALUE_2
+          + ", "
+          + MAP_VARINT_COL_VALUE_2
+          + ", "
+          + SET_TIMEUUID_COL_VALUE_2;
+
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildScyllaExtractNewRecordStateConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    // NewRecordState extracts the "after" field directly
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "list_col": [10],
+          "set_col": ["x"],
+          "map_col": [{"key": 10, "value": "ten"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // DELETE record - after is null, so the record is null
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateListAddElement(int pk) {
+    return new String[] {
+      // Preimage: initial state after insert
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20],
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // Postimage: after appending [30]
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateSetAddElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": ["x", "y"],
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // UPDATE record with full after state
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": ["x", "y", "z"],
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateMapAddElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": [{"key": 10, "value": "ten"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // UPDATE record with full after state
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateListRemoveElement(int pk) {
+    return new String[] {
+      // Preimage: initial state after insert
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // Postimage: after removing [20] - values 10 and 30 remain
+      """
+        {
+          "id": %d,
+          "list_col": [10, 30],
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateSetRemoveElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": ["x", "y", "z"],
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // UPDATE record with full after state (y removed, x and z remain)
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": ["x", "z"],
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateMapRemoveElement(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // UPDATE record with full after state (key 10 removed, key 20 remains)
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": [{"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    return new String[] {
+      // Preimage: initial state after insert
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES),
+      // Postimage: after replacing with new values
+      """
+        {
+          "id": %d,
+          "list_col": [40, 50, 60],
+          "set_col": ["a", "b", "c"],
+          "map_col": [{"key": 30, "value": "thirty"}, {"key": 40, "value": "forty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES_2)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    return new String[] {
+      // Preimage: initial state after insert
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES),
+      // Postimage: all collections set to null
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    return new String[] {
+      // Preimage: initial state after insert
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES),
+      // Postimage: empty collections become null in Scylla
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    return new String[] {
+      // Preimage: initial state with null collections
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // Postimage: populated collections
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    // Empty collections are stored as null in Scylla
+    return new String[] {
+      // Preimage: empty collections become null
+      """
+        {
+          "id": %d,
+          "list_col": null,
+          "set_col": null,
+          "map_col": null,
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL),
+      // Postimage: populated collections
+      """
+        {
+          "id": %d,
+          "list_col": [10, 20, 30],
+          "set_col": ["x", "y", "z"],
+          "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+          %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES)
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsPlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesNonFrozenCollectionsPlainConnectorIT.java
@@ -1,0 +1,843 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesNonFrozenCollectionsPlainConnectorIT
+    extends ScyllaTypesNonFrozenCollectionsBase<String, String> {
+
+  // Expected map values for insert/update tests with all columns populated
+  private static final String MAP_ASCII_COL_VALUE =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key\", \"value\": \"ascii_value\"}]";
+  private static final String MAP_BIGINT_COL_VALUE =
+      "\"map_bigint_col\": [{\"key\": 1234567890123, \"value\": \"bigint_value\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE =
+      "\"map_boolean_col\": [{\"key\": true, \"value\": \"boolean_value\"}]";
+  private static final String MAP_DATE_COL_VALUE =
+      "\"map_date_col\": [{\"key\": 19884, \"value\": \"date_value\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE =
+      "\"map_decimal_col\": [{\"key\": \"12345.67\", \"value\": \"decimal_value\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE =
+      "\"map_double_col\": [{\"key\": 3.14159, \"value\": \"double_value\"}]";
+  private static final String MAP_FLOAT_COL_VALUE =
+      "\"map_float_col\": [{\"key\": 2.71828, \"value\": \"float_value\"}]";
+  private static final String MAP_INET_COL_VALUE =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.1\", \"value\": \"inet_value\"}]";
+  private static final String MAP_INT_COL_VALUE =
+      "\"map_int_col\": [{\"key\": 42, \"value\": \"int_value\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE =
+      "\"map_smallint_col\": [{\"key\": 7, \"value\": \"smallint_value\"}]";
+  private static final String MAP_TEXT_COL_VALUE =
+      "\"map_text_col\": [{\"key\": \"text_key\", \"value\": \"text_value\"}]";
+  private static final String MAP_TIME_COL_VALUE =
+      "\"map_time_col\": [{\"key\": 45296789000000, \"value\": \"time_value\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE =
+      "\"map_timestamp_col\": [{\"key\": 1718022896789, \"value\": \"timestamp_value\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a030-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value\"}]";
+  private static final String MAP_TINYINT_COL_VALUE =
+      "\"map_tinyint_col\": [{\"key\": 5, \"value\": \"tinyint_value\"}]";
+  private static final String MAP_UUID_COL_VALUE =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371c\", \"value\": \"uuid_value\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key\", \"value\": \"varchar_value\"}]";
+  private static final String MAP_VARINT_COL_VALUE =
+      "\"map_varint_col\": [{\"key\": \"999999999\", \"value\": \"varint_value\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE =
+      "\"set_timeuuid_col\": [\"81d4a030-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Expected map values for update tests (different values)
+  private static final String MAP_ASCII_COL_VALUE_2 =
+      "\"map_ascii_col\": [{\"key\": \"ascii_key_2\", \"value\": \"ascii_value_2\"}]";
+  private static final String MAP_BIGINT_COL_VALUE_2 =
+      "\"map_bigint_col\": [{\"key\": 1234567890124, \"value\": \"bigint_value_2\"}]";
+  private static final String MAP_BOOLEAN_COL_VALUE_2 =
+      "\"map_boolean_col\": [{\"key\": false, \"value\": \"boolean_value_2\"}]";
+  private static final String MAP_DATE_COL_VALUE_2 =
+      "\"map_date_col\": [{\"key\": 19885, \"value\": \"date_value_2\"}]";
+  private static final String MAP_DECIMAL_COL_VALUE_2 =
+      "\"map_decimal_col\": [{\"key\": \"98765.43\", \"value\": \"decimal_value_2\"}]";
+  private static final String MAP_DOUBLE_COL_VALUE_2 =
+      "\"map_double_col\": [{\"key\": 2.71828, \"value\": \"double_value_2\"}]";
+  private static final String MAP_FLOAT_COL_VALUE_2 =
+      "\"map_float_col\": [{\"key\": 1.41421, \"value\": \"float_value_2\"}]";
+  private static final String MAP_INET_COL_VALUE_2 =
+      "\"map_inet_col\": [{\"key\": \"127.0.0.2\", \"value\": \"inet_value_2\"}]";
+  private static final String MAP_INT_COL_VALUE_2 =
+      "\"map_int_col\": [{\"key\": 43, \"value\": \"int_value_2\"}]";
+  private static final String MAP_SMALLINT_COL_VALUE_2 =
+      "\"map_smallint_col\": [{\"key\": 8, \"value\": \"smallint_value_2\"}]";
+  private static final String MAP_TEXT_COL_VALUE_2 =
+      "\"map_text_col\": [{\"key\": \"text_key_2\", \"value\": \"text_value_2\"}]";
+  private static final String MAP_TIME_COL_VALUE_2 =
+      "\"map_time_col\": [{\"key\": 3723456000000, \"value\": \"time_value_2\"}]";
+  private static final String MAP_TIMESTAMP_COL_VALUE_2 =
+      "\"map_timestamp_col\": [{\"key\": 1718067723456, \"value\": \"timestamp_value_2\"}]";
+  private static final String MAP_TIMEUUID_COL_VALUE_2 =
+      "\"map_timeuuid_col\": [{\"key\": \"81d4a031-4632-11f0-9484-409dd8f36eba\", \"value\": \"timeuuid_value_2\"}]";
+  private static final String MAP_TINYINT_COL_VALUE_2 =
+      "\"map_tinyint_col\": [{\"key\": 6, \"value\": \"tinyint_value_2\"}]";
+  private static final String MAP_UUID_COL_VALUE_2 =
+      "\"map_uuid_col\": [{\"key\": \"453662fa-db4b-4938-9033-d8523c0a371d\", \"value\": \"uuid_value_2\"}]";
+  private static final String MAP_VARCHAR_COL_VALUE_2 =
+      "\"map_varchar_col\": [{\"key\": \"varchar_key_2\", \"value\": \"varchar_value_2\"}]";
+  private static final String MAP_VARINT_COL_VALUE_2 =
+      "\"map_varint_col\": [{\"key\": \"888888888\", \"value\": \"varint_value_2\"}]";
+  private static final String SET_TIMEUUID_COL_VALUE_2 =
+      "\"set_timeuuid_col\": [\"81d4a031-4632-11f0-9484-409dd8f36eba\"]";
+
+  // Null values for all extra columns
+  private static final String ALL_EXTRA_COLS_NULL =
+      "\"map_ascii_col\": null, \"map_bigint_col\": null, \"map_boolean_col\": null, "
+          + "\"map_date_col\": null, \"map_decimal_col\": null, \"map_double_col\": null, "
+          + "\"map_float_col\": null, \"map_inet_col\": null, \"map_int_col\": null, "
+          + "\"map_smallint_col\": null, \"map_text_col\": null, \"map_time_col\": null, "
+          + "\"map_timestamp_col\": null, \"map_timeuuid_col\": null, \"map_tinyint_col\": null, "
+          + "\"map_uuid_col\": null, \"map_varchar_col\": null, \"map_varint_col\": null, "
+          + "\"set_timeuuid_col\": null";
+
+  // All extra columns with initial values (for insert with values)
+  private static final String ALL_EXTRA_COLS_VALUES =
+      MAP_ASCII_COL_VALUE
+          + ", "
+          + MAP_BIGINT_COL_VALUE
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE
+          + ", "
+          + MAP_DATE_COL_VALUE
+          + ", "
+          + MAP_DECIMAL_COL_VALUE
+          + ", "
+          + MAP_DOUBLE_COL_VALUE
+          + ", "
+          + MAP_FLOAT_COL_VALUE
+          + ", "
+          + MAP_INET_COL_VALUE
+          + ", "
+          + MAP_INT_COL_VALUE
+          + ", "
+          + MAP_SMALLINT_COL_VALUE
+          + ", "
+          + MAP_TEXT_COL_VALUE
+          + ", "
+          + MAP_TIME_COL_VALUE
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE
+          + ", "
+          + MAP_TINYINT_COL_VALUE
+          + ", "
+          + MAP_UUID_COL_VALUE
+          + ", "
+          + MAP_VARCHAR_COL_VALUE
+          + ", "
+          + MAP_VARINT_COL_VALUE
+          + ", "
+          + SET_TIMEUUID_COL_VALUE;
+
+  // All extra columns with updated values
+  private static final String ALL_EXTRA_COLS_VALUES_2 =
+      MAP_ASCII_COL_VALUE_2
+          + ", "
+          + MAP_BIGINT_COL_VALUE_2
+          + ", "
+          + MAP_BOOLEAN_COL_VALUE_2
+          + ", "
+          + MAP_DATE_COL_VALUE_2
+          + ", "
+          + MAP_DECIMAL_COL_VALUE_2
+          + ", "
+          + MAP_DOUBLE_COL_VALUE_2
+          + ", "
+          + MAP_FLOAT_COL_VALUE_2
+          + ", "
+          + MAP_INET_COL_VALUE_2
+          + ", "
+          + MAP_INT_COL_VALUE_2
+          + ", "
+          + MAP_SMALLINT_COL_VALUE_2
+          + ", "
+          + MAP_TEXT_COL_VALUE_2
+          + ", "
+          + MAP_TIME_COL_VALUE_2
+          + ", "
+          + MAP_TIMESTAMP_COL_VALUE_2
+          + ", "
+          + MAP_TIMEUUID_COL_VALUE_2
+          + ", "
+          + MAP_TINYINT_COL_VALUE_2
+          + ", "
+          + MAP_UUID_COL_VALUE_2
+          + ", "
+          + MAP_VARCHAR_COL_VALUE_2
+          + ", "
+          + MAP_VARINT_COL_VALUE_2
+          + ", "
+          + SET_TIMEUUID_COL_VALUE_2;
+
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildPlainConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** Track the current test PK for use in expectedKey(). */
+  private int currentPk;
+
+  /** {@inheritDoc} */
+  @Override
+  protected String expectedKey() {
+    return "{\"id\": " + currentPk + "}";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithValues(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10],
+            "set_col": ["x"],
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // DELETE record - for partition deletes (tables without clustering key),
+      // preimage is not sent in Scylla versions < 2026.1.0
+      """
+        {
+          "before": null,
+          "after": null,
+          "key": {"id": %d},
+          "op": "d",
+          "source": %s
+        }
+        """
+          .formatted(pk, expectedSource()),
+      // Tombstone
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateListAddElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateSetAddElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y"],
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateMapAddElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateListRemoveElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 30],
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateSetRemoveElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "y", "z"],
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": ["x", "z"],
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateMapRemoveElement(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": [{"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToValue(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [40, 50, 60],
+            "set_col": ["a", "b", "c"],
+            "map_col": [{"key": 30, "value": "thirty"}, {"key": 40, "value": "forty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_VALUES_2, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToNull(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromValueToEmpty(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource()),
+      // UPDATE record - empty collections become null in Scylla
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_VALUES, pk, ALL_EXTRA_COLS_NULL, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromNullToValue(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    currentPk = pk;
+    // Empty collections are stored as null in Scylla, so this is similar to null-to-value
+    return new String[] {
+      // INSERT record - empty collections become null
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, expectedSource()),
+      // UPDATE record with full before/after
+      """
+        {
+          "before": {
+            "id": %d,
+            "list_col": null,
+            "set_col": null,
+            "map_col": null,
+            %s
+          },
+          "after": {
+            "id": %d,
+            "list_col": [10, 20, 30],
+            "set_col": ["x", "y", "z"],
+            "map_col": [{"key": 10, "value": "ten"}, {"key": 20, "value": "twenty"}],
+            %s
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, ALL_EXTRA_COLS_NULL, pk, ALL_EXTRA_COLS_VALUES, pk, expectedSource())
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveAvroConnectorIT.java
@@ -260,6 +260,7 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
               pk,
               expectedSource()),
       // UPDATE record with preimage and postimage
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": {
@@ -291,6 +292,26 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -570,12 +591,33 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
   @Override
   String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns (other cols were nil)
+      // INSERT record: before is null, after has untouched_* columns (other cols were nil)
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -594,11 +636,32 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after has all values
+      // UPDATE record: "before" correctly shows NULL for columns that were NULL before the update
+      // Note: Avro format includes all schema fields
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -655,12 +718,33 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
   @Override
   String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns
+      // INSERT record: before is null, after has untouched_* columns
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -679,11 +763,32 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after has new values
+      // UPDATE record: "before" correctly shows NULL for columns that were NULL before the update
+      // Note: Avro format includes all schema fields
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -740,12 +845,33 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
   @Override
   String[] expectedUpdateFromNilToNil(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns
+      // INSERT record: before is null, after has untouched_* columns
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -764,11 +890,32 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after also has only untouched_* columns
+      // UPDATE record: before and after both have untouched_* columns (with null fields)
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -776,6 +923,26 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -974,7 +1141,8 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has values with empty strings, after has only untouched_* columns
+      // UPDATE record: before has values with empty strings, after has untouched_* columns
+      // Note: Avro format includes all schema fields, so null fields appear in the output
       """
         {
           "before": {
@@ -1006,6 +1174,26 @@ public class ScyllaTypesPrimitiveAvroConnectorIT
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT.java
@@ -126,8 +126,39 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
     return new String[] {
       """
         {
+          "id": %d,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
-        """,
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -150,7 +181,11 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": null,
           "uuid_col": null,
           "varchar_col": null,
-          "varint_col": null
+          "varint_col": null,
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
         }
         """
           .formatted(pk)
@@ -160,82 +195,6 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
   @Override
   String[] expectedUpdateFromValueToEmpty(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
-      """
-        {
-          "id": %d,
-          "ascii_col": "",
-          "bigint_col": 1234567890124,
-          "blob_col": "3q2+7w==",
-          "boolean_col": false,
-          "date_col": 19885,
-          "decimal_col": "98765.43",
-          "double_col": 2.71828,
-          "duration_col": "2d1h",
-          "float_col": 1.41421,
-          "inet_col": "127.0.0.2",
-          "int_col": 43,
-          "smallint_col": 8,
-          "text_col": "",
-          "time_col": 3723456000000,
-          "timestamp_col": 1718067723456,
-          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
-          "tinyint_col": 6,
-          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
-          "varchar_col": "",
-          "varint_col": "888888888"
-        }
-        """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromValueToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
-      """
-        {
-          "id": %d,
-          "ascii_col": "ascii2",
-          "bigint_col": 1234567890124,
-          "blob_col": "3q2+7w==",
-          "boolean_col": false,
-          "date_col": 19885,
-          "decimal_col": "98765.43",
-          "double_col": 2.71828,
-          "duration_col": "2d1h",
-          "float_col": 1.41421,
-          "inet_col": "127.0.0.2",
-          "int_col": 43,
-          "smallint_col": 8,
-          "text_col": "value2",
-          "time_col": 3723456000000,
-          "timestamp_col": 1718067723456,
-          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
-          "tinyint_col": 6,
-          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
-          "varchar_col": "varchar text 2",
-          "varint_col": "888888888"
-        }
-        """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromNilToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
       """
         {
           "id": %d,
@@ -258,20 +217,19 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": 5,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
           "varchar_col": "varchar text",
-          "varint_col": "999999999"
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromNilToEmpty(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -294,7 +252,11 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
         }
         """
           .formatted(pk)
@@ -302,48 +264,43 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
   }
 
   @Override
-  String[] expectedUpdateFromNilToNil(int pk) {
+  String[] expectedUpdateFromValueToValue(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
       """
         {
           "id": %d,
-          "ascii_col": null,
-          "bigint_col": null,
-          "blob_col": null,
-          "boolean_col": null,
-          "date_col": null,
-          "decimal_col": null,
-          "double_col": null,
-          "duration_col": null,
-          "float_col": null,
-          "inet_col": null,
-          "int_col": null,
-          "smallint_col": null,
-          "text_col": null,
-          "time_col": null,
-          "timestamp_col": null,
-          "timeuuid_col": null,
-          "tinyint_col": null,
-          "uuid_col": null,
-          "varchar_col": null,
-          "varint_col": null
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromEmptyToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -366,7 +323,11 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "varchar text 2",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
         }
         """
           .formatted(pk)
@@ -374,12 +335,9 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
   }
 
   @Override
-  String[] expectedUpdateFromEmptyToNil(int pk) {
+  String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
+      // Preimage: only untouched columns have values (from insertOnlyUntouchedRow)
       """
         {
           "id": %d,
@@ -402,7 +360,47 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": null,
           "uuid_col": null,
           "varchar_col": null,
-          "varint_col": null
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // Postimage: data columns updated, untouched columns null (not updated)
+      """
+        {
+          "id": %d,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
         }
         """
           .formatted(pk)
@@ -410,12 +408,45 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
   }
 
   @Override
-  String[] expectedUpdateFromEmptyToEmpty(int pk) {
+  String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
+      // Preimage: only untouched columns have values (from insertOnlyUntouchedRow)
       """
         {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
-        """,
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // Postimage: data columns updated to empty values, untouched columns null (not updated)
       """
         {
           "id": %d,
@@ -438,7 +469,300 @@ public class ScyllaTypesPrimitiveLegacyNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToNil(int pk) {
+    return new String[] {
+      // Preimage: only untouched columns have values (from insertOnlyUntouchedRow)
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // Postimage: data columns still null, untouched columns null (not updated)
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    return new String[] {
+      // Preimage: text columns empty, blob is still CAFEBABE (yv66vg==)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      """
+        {
+          "id": %d,
+          "ascii_col": "ascii2",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "value2",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "varchar text 2",
+          "varint_col": "888888888",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToNil(int pk) {
+    return new String[] {
+      // Preimage: text columns empty, blob is still CAFEBABE (yv66vg==)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToEmpty(int pk) {
+    return new String[] {
+      // Preimage: text columns empty, blob is still CAFEBABE (yv66vg==)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "",
+          "varint_col": "888888888",
+          "untouched_text": null,
+          "untouched_int": null,
+          "untouched_boolean": null,
+          "untouched_uuid": null
         }
         """
           .formatted(pk)

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyPreimageDisabledIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyPreimageDisabledIT.java
@@ -139,12 +139,35 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // DELETE record: Without preimages, "before" only contains key fields from the change
-      // itself (not preimage data). For PARTITION_DELETE, the change contains only the PK.
+      // DELETE record: "before" contains all columns with null values for non-key columns
       """
         {
           "before": {
-            "id": %d
+            "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": null,
           "op": "d",
@@ -227,7 +250,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -307,7 +334,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -387,7 +418,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": "varchar text 2"},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -400,12 +435,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
   @Override
   String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      // INSERT record
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -447,7 +502,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": "varchar text"},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -460,12 +519,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
   @Override
   String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
-      // INSERT record
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -507,7 +586,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -520,12 +603,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
   @Override
   String[] expectedUpdateFromNilToNil(int pk) {
     return new String[] {
-      // INSERT record
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -567,7 +670,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -647,7 +754,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": "varchar text 2"},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -727,7 +838,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -807,7 +922,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageDisabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyPreimageEnabledIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveLegacyPreimageEnabledIT.java
@@ -138,13 +138,35 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // DELETE record: This table has only partition key (no clustering key), so DELETE
-      // becomes PARTITION_DELETE. For PARTITION_DELETE in legacy format, only the PK is
-      // captured in "before" as the preimage doesn't include all columns.
+      // DELETE record: "before" contains all columns with null values for non-key columns
       """
         {
           "before": {
-            "id": %d
+            "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": null,
           "op": "d",
@@ -202,8 +224,8 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: before has preimage (only columns being changed), after has postimage
-      // Note: untouched_* columns are NOT in preimage because they're not being changed
+      // UPDATE record: before has preimage, after has postimage
+      // untouched_* columns appear as null since they weren't part of the change
       """
         {
           "before": {
@@ -227,7 +249,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": "varchar text"},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -250,7 +276,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -305,7 +335,7 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed
+      // UPDATE record: preimage and postimage with untouched columns as null
       """
         {
           "before": {
@@ -329,7 +359,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": "varchar text"},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -352,7 +386,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -407,7 +445,7 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed
+      // UPDATE record: preimage and postimage with untouched columns as null
       """
         {
           "before": {
@@ -431,7 +469,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": "varchar text"},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -454,7 +496,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": "varchar text 2"},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -467,12 +513,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
   @Override
   String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -489,11 +555,35 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage has all columns as null, postimage has new values
       """
         {
           "before": {
-            "id": %d
+            "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -516,7 +606,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": "varchar text"},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -529,12 +623,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
   @Override
   String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
-      // INSERT record
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -551,11 +665,35 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage has all columns as null, postimage has new values
       """
         {
           "before": {
-            "id": %d
+            "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -578,7 +716,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -591,12 +733,32 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
   @Override
   String[] expectedUpdateFromNilToNil(int pk) {
     return new String[] {
-      // INSERT record
+      // INSERT record: before is null, after has all columns (most are null)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": {"value": "%s"},
             "untouched_int": {"value": %d},
             "untouched_boolean": {"value": %s},
@@ -613,11 +775,35 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage has all columns with {"value": null}, postimage has null values
       """
         {
           "before": {
-            "id": %d
+            "id": %d,
+            "ascii_col": {"value": null},
+            "bigint_col": {"value": null},
+            "blob_col": {"value": null},
+            "boolean_col": {"value": null},
+            "date_col": {"value": null},
+            "decimal_col": {"value": null},
+            "double_col": {"value": null},
+            "duration_col": {"value": null},
+            "float_col": {"value": null},
+            "inet_col": {"value": null},
+            "int_col": {"value": null},
+            "smallint_col": {"value": null},
+            "text_col": {"value": null},
+            "time_col": {"value": null},
+            "timestamp_col": {"value": null},
+            "timeuuid_col": {"value": null},
+            "tinyint_col": {"value": null},
+            "uuid_col": {"value": null},
+            "varchar_col": {"value": null},
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -640,7 +826,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -695,7 +885,7 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage and postimage with untouched columns as null
       """
         {
           "before": {
@@ -719,7 +909,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -742,7 +936,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": "varchar text 2"},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -797,7 +995,7 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage and postimage with untouched columns as null
       """
         {
           "before": {
@@ -821,7 +1019,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -844,7 +1046,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": null},
             "uuid_col": {"value": null},
             "varchar_col": {"value": null},
-            "varint_col": {"value": null}
+            "varint_col": {"value": null},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s
@@ -899,7 +1105,7 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
               UNTOUCHED_BOOLEAN_VALUE,
               UNTOUCHED_UUID_VALUE,
               expectedSource()),
-      // UPDATE record: preimage only contains columns being changed (not untouched_*)
+      // UPDATE record: preimage and postimage with untouched columns as null
       """
         {
           "before": {
@@ -923,7 +1129,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 5},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371c"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "999999999"}
+            "varint_col": {"value": "999999999"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "after": {
             "id": %d,
@@ -946,7 +1156,11 @@ public class ScyllaTypesPrimitiveLegacyPreimageEnabledIT
             "tinyint_col": {"value": 6},
             "uuid_col": {"value": "453662fa-db4b-4938-9033-d8523c0a371d"},
             "varchar_col": {"value": ""},
-            "varint_col": {"value": "888888888"}
+            "varint_col": {"value": "888888888"},
+            "untouched_text": null,
+            "untouched_int": null,
+            "untouched_boolean": null,
+            "untouched_uuid": null
           },
           "op": "u",
           "source": %s

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitiveNewRecordStateConnectorIT.java
@@ -112,8 +112,39 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
     return new String[] {
       """
         {
+          "id": %d,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
-        """,
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -136,92 +167,25 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": null,
           "uuid_col": null,
           "varchar_col": null,
-          "varint_col": null
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
     };
   }
 
   @Override
   String[] expectedUpdateFromValueToEmpty(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
-      """
-        {
-          "id": %d,
-          "ascii_col": "",
-          "bigint_col": 1234567890124,
-          "blob_col": "3q2+7w==",
-          "boolean_col": false,
-          "date_col": 19885,
-          "decimal_col": "98765.43",
-          "double_col": 2.71828,
-          "duration_col": "2d1h",
-          "float_col": 1.41421,
-          "inet_col": "127.0.0.2",
-          "int_col": 43,
-          "smallint_col": 8,
-          "text_col": "",
-          "time_col": 3723456000000,
-          "timestamp_col": 1718067723456,
-          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
-          "tinyint_col": 6,
-          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
-          "varchar_col": "",
-          "varint_col": "888888888"
-        }
-        """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromValueToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
-      """
-        {
-          "id": %d,
-          "ascii_col": "ascii2",
-          "bigint_col": 1234567890124,
-          "blob_col": "3q2+7w==",
-          "boolean_col": false,
-          "date_col": 19885,
-          "decimal_col": "98765.43",
-          "double_col": 2.71828,
-          "duration_col": "2d1h",
-          "float_col": 1.41421,
-          "inet_col": "127.0.0.2",
-          "int_col": 43,
-          "smallint_col": 8,
-          "text_col": "value2",
-          "time_col": 3723456000000,
-          "timestamp_col": 1718067723456,
-          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
-          "tinyint_col": 6,
-          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
-          "varchar_col": "varchar text 2",
-          "varint_col": "888888888"
-        }
-        """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromNilToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
       """
         {
           "id": %d,
@@ -244,20 +208,19 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": 5,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
           "varchar_col": "varchar text",
-          "varint_col": "999999999"
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromNilToEmpty(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -280,56 +243,60 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
     };
   }
 
   @Override
-  String[] expectedUpdateFromNilToNil(int pk) {
+  String[] expectedUpdateFromValueToValue(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
       """
         {
           "id": %d,
-          "ascii_col": null,
-          "bigint_col": null,
-          "blob_col": null,
-          "boolean_col": null,
-          "date_col": null,
-          "decimal_col": null,
-          "double_col": null,
-          "duration_col": null,
-          "float_col": null,
-          "inet_col": null,
-          "int_col": null,
-          "smallint_col": null,
-          "text_col": null,
-          "time_col": null,
-          "timestamp_col": null,
-          "timeuuid_col": null,
-          "tinyint_col": null,
-          "uuid_col": null,
-          "varchar_col": null,
-          "varint_col": null
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
-    };
-  }
-
-  @Override
-  String[] expectedUpdateFromEmptyToValue(int pk) {
-    return new String[] {
-      """
-        {
-        }
-        """,
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -352,20 +319,25 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "varchar text 2",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
     };
   }
 
   @Override
-  String[] expectedUpdateFromEmptyToNil(int pk) {
+  String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      """
-        {
-        }
-        """,
       """
         {
           "id": %d,
@@ -388,20 +360,95 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": null,
           "uuid_col": null,
           "varchar_col": null,
-          "varint_col": null
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      """
+        {
+          "id": %d,
+          "ascii_col": "ascii",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "value",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "varchar text",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
     };
   }
 
   @Override
-  String[] expectedUpdateFromEmptyToEmpty(int pk) {
+  String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
       """
         {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
-        """,
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
       """
         {
           "id": %d,
@@ -424,10 +471,329 @@ public class ScyllaTypesPrimitiveNewRecordStateConnectorIT
           "tinyint_col": 6,
           "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
           "varchar_col": "",
-          "varint_col": "888888888"
+          "varint_col": "888888888",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
         }
         """
-          .formatted(pk)
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromNilToNil(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToValue(int pk) {
+    return new String[] {
+      // Before: insertEmptyRow uses EMPTY_VALUES_SET1 (SET1 with empty strings)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // After: updateToValuesSet2
+      """
+        {
+          "id": %d,
+          "ascii_col": "ascii2",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "value2",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "varchar text 2",
+          "varint_col": "888888888",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToNil(int pk) {
+    return new String[] {
+      // Before: insertEmptyRow uses EMPTY_VALUES_SET1 (SET1 with empty strings)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // After: updateToNull
+      """
+        {
+          "id": %d,
+          "ascii_col": null,
+          "bigint_col": null,
+          "blob_col": null,
+          "boolean_col": null,
+          "date_col": null,
+          "decimal_col": null,
+          "double_col": null,
+          "duration_col": null,
+          "float_col": null,
+          "inet_col": null,
+          "int_col": null,
+          "smallint_col": null,
+          "text_col": null,
+          "time_col": null,
+          "timestamp_col": null,
+          "timeuuid_col": null,
+          "tinyint_col": null,
+          "uuid_col": null,
+          "varchar_col": null,
+          "varint_col": null,
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFromEmptyToEmpty(int pk) {
+    return new String[] {
+      // Before: insertEmptyRow uses EMPTY_VALUES_SET1 (SET1 with empty strings)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890123,
+          "blob_col": "yv66vg==",
+          "boolean_col": true,
+          "date_col": 19884,
+          "decimal_col": "12345.67",
+          "double_col": 3.14159,
+          "duration_col": "1d12h30m",
+          "float_col": 2.71828,
+          "inet_col": "127.0.0.1",
+          "int_col": 42,
+          "smallint_col": 7,
+          "text_col": "",
+          "time_col": 45296789000000,
+          "timestamp_col": 1718022896789,
+          "timeuuid_col": "81d4a030-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 5,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371c",
+          "varchar_col": "",
+          "varint_col": "999999999",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE),
+      // After: updateToEmptySet2 (SET2 with empty strings)
+      """
+        {
+          "id": %d,
+          "ascii_col": "",
+          "bigint_col": 1234567890124,
+          "blob_col": "3q2+7w==",
+          "boolean_col": false,
+          "date_col": 19885,
+          "decimal_col": "98765.43",
+          "double_col": 2.71828,
+          "duration_col": "2d1h",
+          "float_col": 1.41421,
+          "inet_col": "127.0.0.2",
+          "int_col": 43,
+          "smallint_col": 8,
+          "text_col": "",
+          "time_col": 3723456000000,
+          "timestamp_col": 1718067723456,
+          "timeuuid_col": "81d4a031-4632-11f0-9484-409dd8f36eba",
+          "tinyint_col": 6,
+          "uuid_col": "453662fa-db4b-4938-9033-d8523c0a371d",
+          "varchar_col": "",
+          "varint_col": "888888888",
+          "untouched_text": "%s",
+          "untouched_int": %d,
+          "untouched_boolean": %s,
+          "untouched_uuid": "%s"
+        }
+        """
+          .formatted(
+              pk,
+              UNTOUCHED_TEXT_VALUE,
+              UNTOUCHED_INT_VALUE,
+              UNTOUCHED_BOOLEAN_VALUE,
+              UNTOUCHED_UUID_VALUE)
     };
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitivePlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesPrimitivePlainConnectorIT.java
@@ -188,8 +188,8 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has preimage (state before update), after has postimage (only
-      // non-null values)
+      // UPDATE record: before has preimage (state before update), after has full postimage with
+      // nulls
       """
         {
           "before": {
@@ -221,6 +221,26 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -500,12 +520,32 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
   @Override
   String[] expectedUpdateFromNilToValue(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns (other cols were nil)
+      // INSERT record: before is null, after has all columns (nulls for unset cols)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -524,11 +564,31 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after has all values
+      // UPDATE record: "before" correctly shows NULL for columns that were NULL before the update
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -585,12 +645,32 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
   @Override
   String[] expectedUpdateFromNilToEmpty(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns
+      // INSERT record: before is null, after has all columns (nulls for unset cols)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -609,11 +689,31 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after has new values
+      // UPDATE record: "before" correctly shows NULL for columns that were NULL before the update
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -670,12 +770,32 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
   @Override
   String[] expectedUpdateFromNilToNil(int pk) {
     return new String[] {
-      // INSERT record: before is null, after has only untouched_* columns
+      // INSERT record: before is null, after has all columns (nulls for unset cols)
       """
         {
           "before": null,
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -694,11 +814,31 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has only untouched_* columns, after also has only untouched_* columns
+      // UPDATE record: before has full preimage with nulls, after has full postimage with nulls
       """
         {
           "before": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -706,6 +846,26 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,
@@ -904,7 +1064,7 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
               UNTOUCHED_UUID_VALUE,
               pk,
               expectedSource()),
-      // UPDATE record: before has values with empty strings, after has only untouched_* columns
+      // UPDATE record: before has values with empty strings, after has full postimage with nulls
       """
         {
           "before": {
@@ -936,6 +1096,26 @@ public class ScyllaTypesPrimitivePlainConnectorIT extends ScyllaTypesPrimitiveBa
           },
           "after": {
             "id": %d,
+            "ascii_col": null,
+            "bigint_col": null,
+            "blob_col": null,
+            "boolean_col": null,
+            "date_col": null,
+            "decimal_col": null,
+            "double_col": null,
+            "duration_col": null,
+            "float_col": null,
+            "inet_col": null,
+            "int_col": null,
+            "smallint_col": null,
+            "text_col": null,
+            "time_col": null,
+            "timestamp_col": null,
+            "timeuuid_col": null,
+            "tinyint_col": null,
+            "uuid_col": null,
+            "varchar_col": null,
+            "varint_col": null,
             "untouched_text": "%s",
             "untouched_int": %d,
             "untouched_boolean": %s,

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTAvroConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTAvroConnectorIT.java
@@ -1,0 +1,839 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildAvroConnector;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+
+public class ScyllaTypesUDTAvroConnectorIT
+    extends ScyllaTypesUDTBase<GenericRecord, GenericRecord> {
+
+  @BeforeAll
+  @Override
+  public void setupSuite(TestInfo testInfo) {
+    Assumptions.assumeTrue(
+        KAFKA_PROVIDER == KafkaProvider.CONFLUENT, "Avro tests require Confluent Kafka provider");
+    Assumptions.assumeTrue(
+        KAFKA_CONNECT_MODE == KafkaConnectMode.DISTRIBUTED,
+        "Avro tests require distributed mode, otherwise Avro converter is not available");
+    super.setupSuite(testInfo);
+  }
+
+  @Override
+  KafkaConsumer<GenericRecord, GenericRecord> buildConsumer(
+      String connectorName, String tableName) {
+    return buildAvroConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(GenericRecord value) {
+    return extractIdFromKeyField(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(GenericRecord key) {
+    return extractIdFromRecord(key);
+  }
+
+  private int extractIdFromKeyField(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "key" field first (payload-key)
+    if (record.getSchema().getField("key") != null) {
+      Object key = record.get("key");
+      if (key instanceof GenericRecord) {
+        GenericRecord keyRecord = (GenericRecord) key;
+        if (keyRecord.getSchema().getField("id") != null) {
+          Object id = keyRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to after/before/direct for backwards compatibility
+    return extractIdFromRecord(record);
+  }
+
+  private int extractIdFromRecord(GenericRecord record) {
+    if (record == null) {
+      return -1;
+    }
+    // Try to get "after" field first (standard Debezium envelope)
+    if (record.getSchema().getField("after") != null) {
+      Object after = record.get("after");
+      if (after instanceof GenericRecord) {
+        GenericRecord afterRecord = (GenericRecord) after;
+        if (afterRecord.getSchema().getField("id") != null) {
+          Object id = afterRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Try "before" field (for delete operations)
+    if (record.getSchema().getField("before") != null) {
+      Object before = record.get("before");
+      if (before instanceof GenericRecord) {
+        GenericRecord beforeRecord = (GenericRecord) before;
+        if (beforeRecord.getSchema().getField("id") != null) {
+          Object id = beforeRecord.get("id");
+          if (id instanceof Number) {
+            return ((Number) id).intValue();
+          }
+        }
+      }
+    }
+    // Fallback to direct "id" field (for keys)
+    if (record.getSchema().getField("id") != null) {
+      Object id = record.get("id");
+      if (id instanceof Number) {
+        return ((Number) id).intValue();
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  String[] expectedInsert(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithFrozenUdt(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithNonFrozenUdt(int pk) {
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedInsertWithNonFrozenNestedUdt(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithMap(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithList(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithSet(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      // Verify the INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // DELETE record - for partition deletes (tables without clustering key),
+      // preimage is not sent in Scylla versions < 2026.1.0
+      """
+        {
+          "before": null,
+          "after": null,
+          "key": {"id": %d},
+          "op": "d",
+          "source": %s
+        }
+        """
+          .formatted(pk, expectedSource()),
+      // Tombstone
+      null
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToValue(int pk) {
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 42, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE with frozen UDT changes
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 42, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 99, "b": "updated"},
+            "nf_udt": {"a": 77, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "frozen_udt_with_list": {"l": [4, 5, 6]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["d", "e"]},
+            "nf_udt_with_set": {"s": ["d", "e"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToNull(int pk) {
+    return new String[] {
+      // First record: INSERT with initial values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting frozen UDTs to null
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtField(int pk) {
+    return new String[] {
+      // First record: INSERT with initial values (nf_udt has initial value)
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE with non-frozen UDT field change
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 99, "b": "updated"},
+            "nf_udt": {"a": 100, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "frozen_udt_with_list": {"l": [4, 5, 6]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["d", "e"]},
+            "nf_udt_with_set": {"s": ["d", "e"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenNestedUdtField(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithMapField(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithListField(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithSetField(int pk) {
+    return new String[] {};
+  }
+
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToEmpty(int pk) {
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to empty (all fields null)
+      // Empty UDTs are represented as null in Scylla
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFrozenUdtFromNullToValue(int pk) {
+    return new String[] {
+      // First record: INSERT with all UDT values null
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to populated values
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateFrozenUdtFromEmptyToValue(int pk) {
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      // First record: INSERT with empty UDTs (all fields null -> null)
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to populated values
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToValue(int pk) {
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE replacing non-frozen UDTs entirely
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 99, "b": "updated"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}, {"key": "81d4a033-4632-11f0-9484-409dd8f36eba", "value": "value4"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["d", "e", "f"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToNull(int pk) {
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting non-frozen UDTs to null
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTBase.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTBase.java
@@ -1,0 +1,584 @@
+package com.scylladb.cdc.debezium.connector;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for UDT (User-Defined Types) replication. Tests insert, update, and delete
+ * operations with both frozen and non-frozen UDTs.
+ *
+ * <p>Each test uses a unique primary key (obtained via {@link #reservePk()}) for isolation,
+ * allowing all tests to share a single connector and table.
+ *
+ * @param <K> the type of the Kafka consumer key
+ * @param <V> the type of the Kafka consumer value
+ */
+public abstract class ScyllaTypesUDTBase<K, V> extends ScyllaTypesIT<K, V> {
+
+  /** Returns expected records for inserting UDT columns. */
+  abstract String[] expectedInsert(int pk);
+
+  /** Returns expected records for inserting a row with all UDT columns set to null. */
+  abstract String[] expectedInsertWithNull(int pk);
+
+  /** Returns expected records for inserting a row with UDTs having all fields null (empty UDTs). */
+  abstract String[] expectedInsertWithEmpty(int pk);
+
+  /** Returns expected records for deleting a row with UDT columns. */
+  abstract String[] expectedDelete(int pk);
+
+  // Expected insert values for update test setup
+  /** Returns expected records after inserting a row with frozen UDTs. */
+  abstract String[] expectedInsertWithFrozenUdt(int pk);
+
+  /** Returns expected records after inserting a row with non-frozen UDTs. */
+  abstract String[] expectedInsertWithNonFrozenUdt(int pk);
+
+  /** Returns expected records after inserting a row with nested non-frozen UDTs. */
+  abstract String[] expectedInsertWithNonFrozenNestedUdt(int pk);
+
+  /** Returns expected records after inserting a row with non-frozen UDTs that contain maps. */
+  abstract String[] expectedInsertWithNonFrozenUdtWithMap(int pk);
+
+  /** Returns expected records after inserting a row with non-frozen UDTs that contain lists. */
+  abstract String[] expectedInsertWithNonFrozenUdtWithList(int pk);
+
+  /** Returns expected records after inserting a row with non-frozen UDTs that contain sets. */
+  abstract String[] expectedInsertWithNonFrozenUdtWithSet(int pk);
+
+  // Expected update values
+  /** Returns expected records for updating frozen UDTs from value to value. */
+  abstract String[] expectedUpdateFrozenUdtFromValueToValue(int pk);
+
+  /** Returns expected records for updating frozen UDTs from value to null. */
+  abstract String[] expectedUpdateFrozenUdtFromValueToNull(int pk);
+
+  /** Returns expected records for updating frozen UDTs from value to empty (all fields null). */
+  abstract String[] expectedUpdateFrozenUdtFromValueToEmpty(int pk);
+
+  /** Returns expected records for updating frozen UDTs from null to populated value. */
+  abstract String[] expectedUpdateFrozenUdtFromNullToValue(int pk);
+
+  /**
+   * Returns expected records for updating frozen UDTs from empty (all fields null) to populated
+   * value.
+   */
+  abstract String[] expectedUpdateFrozenUdtFromEmptyToValue(int pk);
+
+  /** Returns expected records for updating a field in a non-frozen UDT. */
+  abstract String[] expectedUpdateNonFrozenUdtField(int pk);
+
+  /** Returns expected records for updating a field in a nested non-frozen UDT. */
+  abstract String[] expectedUpdateNonFrozenNestedUdtField(int pk);
+
+  /** Returns expected records for updating a map field in a non-frozen UDT. */
+  abstract String[] expectedUpdateNonFrozenUdtWithMapField(int pk);
+
+  /** Returns expected records for updating a list field in a non-frozen UDT. */
+  abstract String[] expectedUpdateNonFrozenUdtWithListField(int pk);
+
+  /** Returns expected records for updating a set field in a non-frozen UDT. */
+  abstract String[] expectedUpdateNonFrozenUdtWithSetField(int pk);
+
+  /** Returns expected records for replacing entire non-frozen UDTs with new values. */
+  abstract String[] expectedUpdateNonFrozenUdtFromValueToValue(int pk);
+
+  /** Returns expected records for setting entire non-frozen UDTs to null. */
+  abstract String[] expectedUpdateNonFrozenUdtFromValueToNull(int pk);
+
+  /** Returns whether frozen UDT updates are expected for this test variant. */
+  protected boolean expectFrozenUdtUpdates() {
+    return true;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void createTypesBeforeTable(String keyspaceName) {
+    session.execute("CREATE TYPE IF NOT EXISTS " + keyspaceName + ".simple_udt (a int, b text);");
+    // Inner UDT for nested UDT test
+    session.execute("CREATE TYPE IF NOT EXISTS " + keyspaceName + ".inner_udt (x int, y text);");
+    // Nested UDT containing another UDT
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS "
+            + keyspaceName
+            + ".nested_udt (inner frozen<inner_udt>, z int);");
+    // UDT with map (using timeuuid key for nested collection coverage)
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS "
+            + keyspaceName
+            + ".udt_with_map (m frozen<map<timeuuid, text>>);");
+    // UDT with list
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS " + keyspaceName + ".udt_with_list (l frozen<list<int>>);");
+    // UDT with set
+    session.execute(
+        "CREATE TYPE IF NOT EXISTS " + keyspaceName + ".udt_with_set (s frozen<set<text>>);");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String createTableCql(String tableName) {
+    return "("
+        + "id int PRIMARY KEY,"
+        + "frozen_udt frozen<simple_udt>,"
+        + "nf_udt simple_udt,"
+        + "frozen_nested_udt frozen<nested_udt>,"
+        + "nf_nested_udt nested_udt,"
+        + "frozen_udt_with_map frozen<udt_with_map>,"
+        + "nf_udt_with_map udt_with_map,"
+        + "frozen_udt_with_list frozen<udt_with_list>,"
+        + "nf_udt_with_list udt_with_list,"
+        + "frozen_udt_with_set frozen<udt_with_set>,"
+        + "nf_udt_with_set udt_with_set"
+        + ")";
+  }
+
+  /** Verifies an INSERT with UDT columns emits expected records. */
+  @Test
+  void testInsert() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    String[] expected = expectedInsert(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies an INSERT with all UDT columns set to null. */
+  @Test
+  void testInsertWithNull() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "null, null, null, null, null, null, null, null, null, null"
+            + ");");
+    String[] expected = expectedInsertWithNull(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies an INSERT with UDTs having all fields null (empty UDTs). */
+  @Test
+  void testInsertWithEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: null, b: null}, "
+            + "{a: null, b: null}, "
+            + "{inner: null, z: null}, "
+            + "{inner: null, z: null}, "
+            + "{m: null}, "
+            + "{m: null}, "
+            + "{l: null}, "
+            + "{l: null}, "
+            + "{s: null}, "
+            + "{s: null}"
+            + ");");
+    String[] expected = expectedInsertWithEmpty(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies a DELETE emits expected records for UDT columns. */
+  @Test
+  void testDelete() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute("DELETE FROM " + getSuiteKeyspaceTableName() + " WHERE id = " + pk + ";");
+    String[] expected = expectedDelete(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates to frozen UDTs from value to value. */
+  @Test
+  void testUpdateFrozenUdtFromValueToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 42, b: 'foo'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET frozen_udt = {a: 99, b: 'updated'}, "
+            + "nf_udt.a = 77, "
+            + "frozen_nested_udt = {inner: {x: 11, y: 'updated'}, z: 21}, "
+            + "nf_nested_udt.z = 21, "
+            + "frozen_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'updated1', 81d4a032-4632-11f0-9484-409dd8f36eba: 'value3'}}, "
+            + "nf_udt_with_map.m = {81d4a030-4632-11f0-9484-409dd8f36eba: 'updated1', 81d4a032-4632-11f0-9484-409dd8f36eba: 'value3'}, "
+            + "frozen_udt_with_list = {l: [4, 5, 6]}, "
+            + "nf_udt_with_list.l = [4, 5, 6], "
+            + "frozen_udt_with_set = {s: {'d', 'e'}}, "
+            + "nf_udt_with_set.s = {'d', 'e'} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    if (expectFrozenUdtUpdates()) {
+      String[] expected = expectedUpdateFrozenUdtFromValueToValue(pk);
+      waitAndAssert(pk, expected);
+    } else {
+      String[] expected = expectedInsertWithFrozenUdt(pk);
+      waitAndAssert(pk, expected);
+    }
+  }
+
+  /** Verifies updates to frozen UDTs from value to null. */
+  @Test
+  void testUpdateFrozenUdtFromValueToNull() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "null, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET frozen_udt = null, "
+            + "nf_udt = null, "
+            + "frozen_nested_udt = null, "
+            + "nf_nested_udt = null, "
+            + "frozen_udt_with_map = null, "
+            + "nf_udt_with_map = null, "
+            + "frozen_udt_with_list = null, "
+            + "nf_udt_with_list = null, "
+            + "frozen_udt_with_set = null, "
+            + "nf_udt_with_set = null "
+            + "WHERE id = "
+            + pk
+            + ";");
+    if (expectFrozenUdtUpdates()) {
+      String[] expected = expectedUpdateFrozenUdtFromValueToNull(pk);
+      waitAndAssert(pk, expected);
+    } else {
+      String[] expected = expectedInsertWithFrozenUdt(pk);
+      waitAndAssert(pk, expected);
+    }
+  }
+
+  /** Verifies updates to a field within a non-frozen UDT. */
+  @Test
+  void testUpdateNonFrozenUdtField() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "null, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET nf_udt.a = 100, "
+            + "frozen_udt = {a: 99, b: 'updated'}, "
+            + "frozen_nested_udt = {inner: {x: 11, y: 'updated'}, z: 21}, "
+            + "nf_nested_udt.z = 21, "
+            + "frozen_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'updated1', 81d4a032-4632-11f0-9484-409dd8f36eba: 'value3'}}, "
+            + "nf_udt_with_map.m = {81d4a030-4632-11f0-9484-409dd8f36eba: 'updated1', 81d4a032-4632-11f0-9484-409dd8f36eba: 'value3'}, "
+            + "frozen_udt_with_list = {l: [4, 5, 6]}, "
+            + "nf_udt_with_list.l = [4, 5, 6], "
+            + "frozen_udt_with_set = {s: {'d', 'e'}}, "
+            + "nf_udt_with_set.s = {'d', 'e'} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateNonFrozenUdtField(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies updates to frozen UDTs from value to empty (all fields null). */
+  @Test
+  void testUpdateFrozenUdtFromValueToEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET frozen_udt = {a: null, b: null}, "
+            + "nf_udt = {a: null, b: null}, "
+            + "frozen_nested_udt = {inner: null, z: null}, "
+            + "nf_nested_udt = {inner: null, z: null}, "
+            + "frozen_udt_with_map = {m: null}, "
+            + "nf_udt_with_map = {m: null}, "
+            + "frozen_udt_with_list = {l: null}, "
+            + "nf_udt_with_list = {l: null}, "
+            + "frozen_udt_with_set = {s: null}, "
+            + "nf_udt_with_set = {s: null} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    if (expectFrozenUdtUpdates()) {
+      String[] expected = expectedUpdateFrozenUdtFromValueToEmpty(pk);
+      waitAndAssert(pk, expected);
+    } else {
+      String[] expected = expectedInsert(pk);
+      waitAndAssert(pk, expected);
+    }
+  }
+
+  /** Verifies updates to frozen UDTs from null to populated value. */
+  @Test
+  void testUpdateFrozenUdtFromNullToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "null, null, null, null, null, null, null, null, null, null"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET frozen_udt = {a: 42, b: 'foo'}, "
+            + "nf_udt = {a: 7, b: 'bar'}, "
+            + "frozen_nested_udt = {inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "nf_nested_udt = {inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "frozen_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "nf_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "frozen_udt_with_list = {l: [1, 2, 3]}, "
+            + "nf_udt_with_list = {l: [1, 2, 3]}, "
+            + "frozen_udt_with_set = {s: {'a', 'b', 'c'}}, "
+            + "nf_udt_with_set = {s: {'a', 'b', 'c'}} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    if (expectFrozenUdtUpdates()) {
+      String[] expected = expectedUpdateFrozenUdtFromNullToValue(pk);
+      waitAndAssert(pk, expected);
+    } else {
+      String[] expected = expectedInsertWithNull(pk);
+      waitAndAssert(pk, expected);
+    }
+  }
+
+  /** Verifies updates to frozen UDTs from empty (all fields null) to populated value. */
+  @Test
+  void testUpdateFrozenUdtFromEmptyToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: null, b: null}, "
+            + "{a: null, b: null}, "
+            + "{inner: null, z: null}, "
+            + "{inner: null, z: null}, "
+            + "{m: null}, "
+            + "{m: null}, "
+            + "{l: null}, "
+            + "{l: null}, "
+            + "{s: null}, "
+            + "{s: null}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET frozen_udt = {a: 42, b: 'foo'}, "
+            + "nf_udt = {a: 7, b: 'bar'}, "
+            + "frozen_nested_udt = {inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "nf_nested_udt = {inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "frozen_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "nf_udt_with_map = {m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "frozen_udt_with_list = {l: [1, 2, 3]}, "
+            + "nf_udt_with_list = {l: [1, 2, 3]}, "
+            + "frozen_udt_with_set = {s: {'a', 'b', 'c'}}, "
+            + "nf_udt_with_set = {s: {'a', 'b', 'c'}} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    if (expectFrozenUdtUpdates()) {
+      String[] expected = expectedUpdateFrozenUdtFromEmptyToValue(pk);
+      waitAndAssert(pk, expected);
+    } else {
+      String[] expected = expectedInsertWithEmpty(pk);
+      waitAndAssert(pk, expected);
+    }
+  }
+
+  /** Verifies replacing entire non-frozen UDTs with new values. */
+  @Test
+  void testUpdateNonFrozenUdtFromValueToValue() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET nf_udt = {a: 99, b: 'updated'}, "
+            + "nf_nested_udt = {inner: {x: 11, y: 'updated'}, z: 21}, "
+            + "nf_udt_with_map = {m: {81d4a032-4632-11f0-9484-409dd8f36eba: 'value3', 81d4a033-4632-11f0-9484-409dd8f36eba: 'value4'}}, "
+            + "nf_udt_with_list = {l: [4, 5, 6]}, "
+            + "nf_udt_with_set = {s: {'d', 'e', 'f'}} "
+            + "WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateNonFrozenUdtFromValueToValue(pk);
+    waitAndAssert(pk, expected);
+  }
+
+  /** Verifies setting entire non-frozen UDTs to null. */
+  @Test
+  void testUpdateNonFrozenUdtFromValueToNull() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO "
+            + getSuiteKeyspaceTableName()
+            + " (id, frozen_udt, nf_udt, frozen_nested_udt, nf_nested_udt, "
+            + "frozen_udt_with_map, nf_udt_with_map, frozen_udt_with_list, nf_udt_with_list, "
+            + "frozen_udt_with_set, nf_udt_with_set) VALUES ("
+            + pk
+            + ", "
+            + "{a: 42, b: 'foo'}, "
+            + "{a: 7, b: 'bar'}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{inner: {x: 10, y: 'hello'}, z: 20}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{m: {81d4a030-4632-11f0-9484-409dd8f36eba: 'value1', 81d4a031-4632-11f0-9484-409dd8f36eba: 'value2'}}, "
+            + "{l: [1, 2, 3]}, "
+            + "{l: [1, 2, 3]}, "
+            + "{s: {'a', 'b', 'c'}}, "
+            + "{s: {'a', 'b', 'c'}}"
+            + ");");
+    session.execute(
+        "UPDATE "
+            + getSuiteKeyspaceTableName()
+            + " SET nf_udt = null, "
+            + "nf_nested_udt = null, "
+            + "nf_udt_with_map = null, "
+            + "nf_udt_with_list = null, "
+            + "nf_udt_with_set = null "
+            + "WHERE id = "
+            + pk
+            + ";");
+    String[] expected = expectedUpdateNonFrozenUdtFromValueToNull(pk);
+    waitAndAssert(pk, expected);
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTNewRecordStateConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTNewRecordStateConnectorIT.java
@@ -1,0 +1,575 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildScyllaExtractNewRecordStateConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesUDTNewRecordStateConnectorIT extends ScyllaTypesUDTBase<String, String> {
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildScyllaExtractNewRecordStateConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsert(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithFrozenUdt(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": null,
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdt(int pk) {
+    return new String[] {
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenNestedUdt(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithMap(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithList(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithSet(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // DELETE record - after is null, so the record is null
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToValue(int pk) {
+    // Full before/after states with postimage enabled
+    // Empty UDTs (all fields null) are represented as null for consistency
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 42, "b": "foo"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // UPDATE record with full after state (postimage)
+      // nf_udt.a updated from 42 to 77, b preserved as "foo"
+      // nf_nested_udt preserves inner from original, only z changes
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 99, "b": "updated"},
+          "nf_udt": {"a": 77, "b": "foo"},
+          "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+          "frozen_udt_with_list": {"l": [4, 5, 6]},
+          "nf_udt_with_list": {"l": [4, 5, 6]},
+          "frozen_udt_with_set": {"s": ["d", "e"]},
+          "nf_udt_with_set": {"s": ["d", "e"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToNull(int pk) {
+    // Full before/after states with postimage enabled
+    // Empty UDTs (all fields null) are represented as null for consistency
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": null,
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // UPDATE record with full after state (postimage)
+      // Empty UDTs (all fields null) are now represented as null
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtField(int pk) {
+    // Full before/after states with postimage enabled
+    return new String[] {
+      // INSERT record
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // UPDATE record with full after state (postimage)
+      // nf_udt preserves b='bar' from original, a changes to 100
+      // nf_nested_udt preserves inner from original, z changes to 21
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 99, "b": "updated"},
+          "nf_udt": {"a": 100, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+          "frozen_udt_with_list": {"l": [4, 5, 6]},
+          "nf_udt_with_list": {"l": [4, 5, 6]},
+          "frozen_udt_with_set": {"s": ["d", "e"]},
+          "nf_udt_with_set": {"s": ["d", "e"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenNestedUdtField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithMapField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithListField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithSetField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToEmpty(int pk) {
+    return new String[] {
+      // Preimage: initial state with all UDT values
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // Postimage: empty UDTs (all fields null) become null
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromNullToValue(int pk) {
+    return new String[] {
+      // Preimage: initial state with null UDTs
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk),
+      // Postimage: populated UDTs
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromEmptyToValue(int pk) {
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      // Preimage: empty UDTs (all fields null) become null
+      """
+        {
+          "id": %d,
+          "frozen_udt": null,
+          "nf_udt": null,
+          "frozen_nested_udt": null,
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": null,
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": null,
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": null,
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk),
+      // Postimage: populated UDTs
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToValue(int pk) {
+    return new String[] {
+      // Preimage: initial state with all UDT values
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // Postimage: non-frozen UDTs replaced with new values
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 99, "b": "updated"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}, {"key": "81d4a033-4632-11f0-9484-409dd8f36eba", "value": "value4"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [4, 5, 6]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["d", "e", "f"]}
+        }
+        """
+          .formatted(pk)
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToNull(int pk) {
+    return new String[] {
+      // Preimage: initial state with all UDT values
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": {"a": 7, "b": "bar"},
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": {"l": [1, 2, 3]},
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": {"s": ["a", "b", "c"]}
+        }
+        """
+          .formatted(pk),
+      // Postimage: non-frozen UDTs set to null
+      """
+        {
+          "id": %d,
+          "frozen_udt": {"a": 42, "b": "foo"},
+          "nf_udt": null,
+          "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+          "nf_nested_udt": null,
+          "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+          "nf_udt_with_map": null,
+          "frozen_udt_with_list": {"l": [1, 2, 3]},
+          "nf_udt_with_list": null,
+          "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+          "nf_udt_with_set": null
+        }
+        """
+          .formatted(pk)
+    };
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTPlainConnectorIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaTypesUDTPlainConnectorIT.java
@@ -1,0 +1,830 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.KafkaConnectUtils.buildPlainConnector;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public class ScyllaTypesUDTPlainConnectorIT extends ScyllaTypesUDTBase<String, String> {
+  /** {@inheritDoc} */
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    return buildPlainConnector(connectorName, tableName);
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  private int extractIdFromJson(String json) {
+    if (json == null) {
+      return -1;
+    }
+    int idIndex = json.indexOf("\"id\":");
+    if (idIndex == -1) {
+      return -1;
+    }
+    int start = idIndex + 5;
+    while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+      start++;
+    }
+    int end = start;
+    while (end < json.length()
+        && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) {
+      end++;
+    }
+    if (end > start) {
+      return Integer.parseInt(json.substring(start, end));
+    }
+    return -1;
+  }
+
+  /** Track the current test PK for use in expectedKey(). */
+  private int currentPk;
+
+  /** {@inheritDoc} */
+  @Override
+  protected String expectedKey() {
+    return "{\"id\": " + currentPk + "}";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsert(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNull(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithEmpty(int pk) {
+    currentPk = pk;
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithFrozenUdt(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdt(int pk) {
+    currentPk = pk;
+    return new String[] {
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenNestedUdt(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithMap(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithList(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedInsertWithNonFrozenUdtWithSet(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedDelete(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // Verify the INSERT record
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // DELETE record - for partition deletes (tables without clustering key),
+      // preimage is not sent in Scylla versions < 2026.1.0
+      """
+        {
+          "before": null,
+          "after": null,
+          "key": {"id": %d},
+          "op": "d",
+          "source": %s
+        }
+        """
+          .formatted(pk, expectedSource()),
+      // Tombstone
+      null
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToValue(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 42, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE with frozen UDT changes
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 42, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 99, "b": "updated"},
+            "nf_udt": {"a": 77, "b": "foo"},
+            "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "frozen_udt_with_list": {"l": [4, 5, 6]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["d", "e"]},
+            "nf_udt_with_set": {"s": ["d", "e"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToNull(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with initial values
+      // Note: non-frozen UDTs that are null are represented as null
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting frozen UDTs to null
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtField(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with initial values (nf_udt has initial value)
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE with non-frozen UDT field change
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 99, "b": "updated"},
+            "nf_udt": {"a": 100, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "updated1"}, {"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}]},
+            "frozen_udt_with_list": {"l": [4, 5, 6]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["d", "e"]},
+            "nf_udt_with_set": {"s": ["d", "e"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenNestedUdtField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithMapField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithListField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtWithSetField(int pk) {
+    return new String[] {};
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromValueToEmpty(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to empty (all fields null)
+      // Empty UDTs are represented as null in Scylla
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromNullToValue(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with all UDT values null
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to populated values
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateFrozenUdtFromEmptyToValue(int pk) {
+    currentPk = pk;
+    // Empty UDTs (all fields null) are represented as null in Scylla
+    return new String[] {
+      // First record: INSERT with empty UDTs (all fields null -> null)
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting UDTs to populated values
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": null,
+            "nf_udt": null,
+            "frozen_nested_udt": null,
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": null,
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": null,
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": null,
+            "nf_udt_with_set": null
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToValue(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE replacing non-frozen UDTs entirely
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 99, "b": "updated"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 11, "y": "updated"}, "z": 21},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a032-4632-11f0-9484-409dd8f36eba", "value": "value3"}, {"key": "81d4a033-4632-11f0-9484-409dd8f36eba", "value": "value4"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [4, 5, 6]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["d", "e", "f"]}
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  String[] expectedUpdateNonFrozenUdtFromValueToNull(int pk) {
+    currentPk = pk;
+    return new String[] {
+      // First record: INSERT with all UDT values
+      """
+        {
+          "before": null,
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "key": {"id": %d},
+          "op": "c",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, expectedSource()),
+      // Second record: UPDATE setting non-frozen UDTs to null
+      """
+        {
+          "before": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": {"a": 7, "b": "bar"},
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": {"l": [1, 2, 3]},
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": {"s": ["a", "b", "c"]}
+          },
+          "after": {
+            "id": %d,
+            "frozen_udt": {"a": 42, "b": "foo"},
+            "nf_udt": null,
+            "frozen_nested_udt": {"inner": {"x": 10, "y": "hello"}, "z": 20},
+            "nf_nested_udt": null,
+            "frozen_udt_with_map": {"m": [{"key": "81d4a030-4632-11f0-9484-409dd8f36eba", "value": "value1"}, {"key": "81d4a031-4632-11f0-9484-409dd8f36eba", "value": "value2"}]},
+            "nf_udt_with_map": null,
+            "frozen_udt_with_list": {"l": [1, 2, 3]},
+            "nf_udt_with_list": null,
+            "frozen_udt_with_set": {"s": ["a", "b", "c"]},
+            "nf_udt_with_set": null
+          },
+          "key": {"id": %d},
+          "op": "u",
+          "source": %s
+        }
+        """
+          .formatted(pk, pk, pk, expectedSource())
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add support for non-frozen collections (list, set, map) in CDC replication
- Add support for frozen and non-frozen UDTs (User-Defined Types) including nested UDTs
- Extend `CdcIncludeBeforeAfterBase` test schema with primitive types, non-frozen collections, and frozen collections
- Add comprehensive integration tests for collection and UDT operations (insert, update, delete)

## Test plan
- [x] All added tests should pass