### PR TITLE
build: add maven-surefire-plugin for unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.4</version>
                 <executions>


### PR DESCRIPTION
## Summary
- Add maven-surefire-plugin v3.5.4 to enable unit test execution with `mvn test`
- Without this, the default surefire version doesn't support JUnit 5, so no tests run

## Test plan
- [x] Verified `mvn test` now runs unit tests