### PR TITLE
feat: bump `jackson-core` dependency with version `2.18.6` to address…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.3</log4j.version>
         <jackson-databind.version>2.20.1</jackson-databind.version>
+        <jackson-core.version>2.18.6</jackson-core.version>
         <guava.version>33.5.0-jre</guava.version>
         <jetty.version>12.1.5</jetty.version>
         <commons.version>3.19.0</commons.version>
@@ -239,6 +240,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
+            </dependency>
+            <!-- Temporary overriding a transitional dependency from devezium-core to address GHSA-72hv-8253-57qq -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
… vulnerability 🐛

Bumping up `jackson-core`, a transitional dependency coming with `debezium-core`, to fix a vulnerability.