### PR TITLE
feat: add initial lookback config to reduce cluster load on first start

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -196,6 +196,22 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
           .withValidation(Field::isNonNegativeInteger)
           .withDefault(0);
 
+  public static final Field INITIAL_LOOKBACK_MS =
+      Field.create("scylla.initial.lookback.ms")
+          .withDisplayName("Initial lookback window (ms)")
+          .withType(ConfigDef.Type.LONG)
+          .withWidth(ConfigDef.Width.MEDIUM)
+          .withImportance(ConfigDef.Importance.MEDIUM)
+          .withDescription(
+              "Maximum time in milliseconds to look back when the connector starts without saved offsets. "
+                  + "When set to a positive value, the connector will begin reading CDC changes from "
+                  + "(current time - this value) instead of from the beginning of the first CDC generation. "
+                  + "This prevents the connector from scanning through a potentially large number of empty "
+                  + "windows on first start, reducing cluster load. Set to 0 to start from the beginning "
+                  + "of the first CDC generation (original behavior). Value expressed in milliseconds.")
+          .withValidation(Field::isNonNegativeLong)
+          .withDefault(0L);
+
   public static final CQLConfiguration.ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL =
       CQLConfiguration.ConsistencyLevel.QUORUM;
   public static final Field CONSISTENCY_LEVEL =
@@ -483,6 +499,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
               QUERY_TIME_WINDOW_SIZE,
               CONFIDENCE_WINDOW_SIZE,
               MINIMAL_WAIT_FOR_WINDOW_MS,
+              INITIAL_LOOKBACK_MS,
               CDC_OUTPUT_FORMAT,
               PREIMAGES_ENABLED,
               CDC_INCLUDE_BEFORE,
@@ -621,6 +638,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
 
   public long getMinimalWaitForWindowMs() {
     return config.getInteger(ScyllaConnectorConfig.MINIMAL_WAIT_FOR_WINDOW_MS);
+  }
+
+  public long getInitialLookbackMs() {
+    return config.getLong(ScyllaConnectorConfig.INITIAL_LOOKBACK_MS);
   }
 
   public long getHeartbeatIntervalMs() {

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorTask.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorTask.java
@@ -194,6 +194,19 @@ public class ScyllaConnectorTask extends BaseSourceTask<ScyllaPartition, ScyllaO
                 }
                 TaskState taskState = new TaskState(windowStart, windowEnd, changeId);
                 sourceInfo.setTaskState(taskState);
+              } else {
+                long lookbackMs = connectorConfig.getInitialLookbackMs();
+                if (lookbackMs > 0) {
+                  long queryWindowMs = connectorConfig.getQueryTimeWindowSizeMs();
+                  long nowMs = System.currentTimeMillis();
+                  long startMs = nowMs - lookbackMs;
+                  long endMs = Math.min(startMs + queryWindowMs, nowMs);
+                  Timestamp windowStart = new Timestamp(new Date(startMs));
+                  Timestamp windowEnd = new Timestamp(new Date(endMs));
+                  sourceInfo.setTaskState(new TaskState(windowStart, windowEnd, Optional.empty()));
+                  logger.info(
+                      "No saved offset for task, applying initial lookback of {} ms", lookbackMs);
+                }
               }
             });
     return new ScyllaOffsetContext(sourceInfos, new TransactionContext());


### PR DESCRIPTION
## Summary
- Adds new `scylla.initial.lookback.ms` configuration option (default: `0` / disabled)
- When set to a positive value, the connector starts reading from `now - lookbackMs` on first start instead of from the first CDC generation
- Prevents scanning thousands of empty time windows on empty/sparse tables, reducing unnecessary cluster CPU load

## Usage
```properties
# Only look back 1 minute on first start (for tables where you only care about future changes)
scylla.initial.lookback.ms=60000

# Look back 1 hour
scylla.initial.lookback.ms=3600000
```

When `0` (default), the original behavior is preserved — the connector starts from the first CDC generation.

## Test plan
- [x] Verify connector starts from the lookback window when `scylla.initial.lookback.ms` is set and no saved offsets exist
- [x] Verify connector ignores lookback and uses saved offsets when they exist (restart scenario)
- [x] Verify original behavior when `scylla.initial.lookback.ms=0` (default)
- [x] Verify with empty table: confirm reduced query volume to cluster during catch-up