### PR TITLE
feat: attach compiled JAR and Kafka Connect ZIP to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,3 +120,9 @@ jobs:
         run: |
           git status && git log -3
           git push origin --follow-tags -v
+
+      - name: Create GitHub Release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make github-release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+RELEASE_TAG := $(shell git describe --tags --abbrev=0)
+RELEASE_VERSION := $(RELEASE_TAG:v%=%)
+ARTIFACT_ID := scylla-cdc-source-connector
+CHECKOUT_TARGET := target/checkout/target
+
+FAT_JAR := $(CHECKOUT_TARGET)/fat-jar/$(ARTIFACT_ID)-$(RELEASE_VERSION)-jar-with-dependencies.jar
+CONNECT_ZIP := $(CHECKOUT_TARGET)/components/packages/scylladb-$(ARTIFACT_ID)-$(RELEASE_VERSION).zip
+
+.PHONY: github-release
+
+github-release:
+	gh release create "$(RELEASE_TAG)" \
+		"$(FAT_JAR)" \
+		"$(CONNECT_ZIP)" \
+		--title "Release $(RELEASE_VERSION)" \
+		--generate-notes


### PR DESCRIPTION
## Summary
- Add a `Makefile` with a `github-release` target that creates a GitHub Release and uploads the fat JAR and Kafka Connect ZIP as release assets
- Update the release workflow to call `make github-release` after pushing the tag (skipped on dry-runs)

## Artifacts attached to each release
1. **Fat JAR** (`scylla-cdc-source-connector-{version}-jar-with-dependencies.jar`) — compiled project with all dependencies
2. **Kafka Connect ZIP** (`scylladb-scylla-cdc-source-connector-{version}.zip`) — Confluent Hub-compatible connector package

## Test plan
- [x] Run the release workflow with `dry-run: true` and verify the release step is skipped
- [x] Run a release and verify both artifacts appear on the GitHub Release page