### PR TITLE
fix: use task's generation ID instead of fetching first generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>8.1.1-ccs</kafka.version>
         <scylla.driver.version>3.11.5.11</scylla.driver.version>
-        <scylla.cdc.java.version>1.3.10</scylla.cdc.java.version>
+        <scylla.cdc.java.version>1.3.11</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.3</log4j.version>

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -1,10 +1,9 @@
 package com.scylladb.cdc.debezium.connector;
 
-import com.scylladb.cdc.cql.driver3.Driver3MasterCQL;
 import com.scylladb.cdc.cql.driver3.Driver3Session;
 import com.scylladb.cdc.cql.driver3.Driver3WorkerCQL;
+import com.scylladb.cdc.model.GenerationId;
 import com.scylladb.cdc.model.RetryBackoff;
-import com.scylladb.cdc.model.master.GenerationMetadata;
 import com.scylladb.cdc.model.worker.TaskAndRawChangeConsumer;
 import com.scylladb.cdc.model.worker.Worker;
 import com.scylladb.cdc.model.worker.WorkerConfiguration;
@@ -14,11 +13,7 @@ import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -29,8 +24,6 @@ public class ScyllaStreamingChangeEventSource
     implements StreamingChangeEventSource<ScyllaPartition, ScyllaOffsetContext> {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ScyllaStreamingChangeEventSource.class);
-  private static final int FETCH_GROUPED_TASKS_TIMEOUT_SECONDS = 30;
-
   private final ScyllaConnectorConfig configuration;
   private ScyllaTaskContext taskContext;
   private final DatabaseSchema<CollectionId> schema;
@@ -104,57 +97,28 @@ public class ScyllaStreamingChangeEventSource
   }
 
   /**
-   * Runs the CDC worker tasks. This method blocks while waiting for grouped tasks to be fetched.
+   * Runs the CDC worker with tasks from the task context.
    *
-   * <p><b>Note:</b> This method must be called from a blocking context. Do not call from an event
-   * loop or thread pool that expects non-blocking operations, as it may block the calling thread.
+   * <p>Constructs {@link GroupedTasks} directly from the task context using the generation ID
+   * embedded in the tasks themselves, avoiding a redundant database query. The master already
+   * validated the generation when it assigned these tasks.
    *
-   * @param session the Scylla session
-   * @param taskContext the task context
+   * @param session the Scylla session (unused after scylla-cdc-java 1.3.11, kept for future use)
+   * @param taskContext the task context containing assigned tasks
    * @param worker the CDC worker
-   * @throws InterruptedException if the thread is interrupted while waiting
-   * @throws ConnectException if fetching grouped tasks fails or times out
+   * @throws InterruptedException if the thread is interrupted
+   * @throws ConnectException if the worker fails to execute
    */
   private void runWorker(Driver3Session session, ScyllaTaskContext taskContext, Worker worker)
       throws InterruptedException {
     try {
-      GroupedTasks tasks =
-          fetchGroupedTasks(session, taskContext)
-              .get(FETCH_GROUPED_TASKS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-      worker.run(tasks);
-    } catch (TimeoutException e) {
-      throw new ConnectException(
-          "Timed out after "
-              + FETCH_GROUPED_TASKS_TIMEOUT_SECONDS
-              + " seconds while fetching grouped tasks",
-          e);
-    } catch (CompletionException | ExecutionException e) {
+      var tasks =
+          taskContext.getTasks().stream().collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+      GenerationId generationId = taskContext.getTasks().get(0).getKey().getGenerationId();
+      worker.run(new GroupedTasks(tasks, generationId));
+    } catch (ExecutionException e) {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
       throw new ConnectException("Failed to execute CDC worker tasks", cause);
     }
-  }
-
-  private CompletableFuture<GroupedTasks> fetchGroupedTasks(
-      Driver3Session session, ScyllaTaskContext taskContext) {
-    var tasks =
-        taskContext.getTasks().stream().collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-    return fetchGenerationMetadata(session)
-        .thenApply(generationMetadata -> new GroupedTasks(tasks, generationMetadata));
-  }
-
-  private CompletableFuture<GenerationMetadata> fetchGenerationMetadata(Driver3Session session) {
-    var masterCql = new Driver3MasterCQL(session);
-    return masterCql
-        .fetchFirstGenerationId()
-        .thenApply(
-            opt ->
-                opt.orElseThrow(
-                    () ->
-                        new IllegalStateException(
-                            "No generation ID found in CDC generation table. "
-                                + "This may be caused by CDC not being enabled on the relevant tables, or the CDC generation table being empty. "
-                                + "Please ensure that CDC is enabled and the generation table is populated. "
-                                + "Refer to the Scylla CDC documentation for setup and troubleshooting steps.")))
-        .thenCompose(firstGenerationId -> masterCql.fetchGenerationMetadata(firstGenerationId));
   }
 }


### PR DESCRIPTION
## Summary

- Bump scylla-cdc-java from 1.3.9 to 1.3.11 (includes scylladb/scylla-cdc-java#176)
- Construct `GroupedTasks` directly from task context using the `GenerationId` embedded in the tasks, instead of fetching generation metadata from the database
- Eliminates the redundant `fetchFirstGenerationId()` + `fetchGenerationMetadata()` DB queries entirely

## Root Cause

The worker called `fetchFirstGenerationId()` which queries from epoch and returns the earliest CDC generation. When the master advanced past the first generation (e.g., after topology changes), the worker fetched metadata for a different generation than its tasks, failing the `GroupedTasks` precondition: `Tasks from different generations`.

With scylla-cdc-java 1.3.11, `GroupedTasks` supports construction with just a `GenerationId` (no `GenerationMetadata` needed). Since CDC generations are immutable and the `Worker` only uses `getGenerationId()` + `getTasks()`, the full metadata fetch was unnecessary.

## Test plan

- [x] Compiles cleanly
- [x] Unit tests pass
- [x] Integration test with a Scylla cluster that has undergone topology changes (multiple CDC generations)

Fixes #245
Depends on scylladb/scylla-cdc-java#176