### PR TITLE
fix: align jackson-core to 2.20.1 to match jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,8 @@
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.3</log4j.version>
-        <jackson-databind.version>2.20.1</jackson-databind.version>
-        <jackson-core.version>2.18.6</jackson-core.version>
+        <jackson-databind.version>2.21.1</jackson-databind.version>
+        <jackson-core.version>2.21.1</jackson-core.version>
         <guava.version>33.5.0-jre</guava.version>
         <jetty.version>12.1.6</jetty.version>
         <commons.version>3.19.0</commons.version>
@@ -241,7 +241,7 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
             </dependency>
-            <!-- Temporary overriding a transitional dependency from devezium-core to address GHSA-72hv-8253-57qq -->
+            <!-- Override jackson-core pulled transitively from debezium-core to address GHSA-72hv-8253-57qq; version must match jackson-databind -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
## Summary
- `jackson-databind 2.20.1` carries a known vulnerability and must not be shipped
- `jackson-core 2.18.6` (previous override) was mismatched against `jackson-databind 2.20.1` — databind requires core of the same minor version
- Bumps both `jackson-core` and `jackson-databind` to `2.21.1`, the patched version, keeping them in sync
- The explicit `jackson-core` override in `dependencyManagement` is retained since `debezium-core` still pulls in an older transitive version

## Test plan
- `mvn dependency:tree` confirms both `jackson-core` and `jackson-databind` resolve to `2.21.1` with no conflicts
- `mvn compile` passes cleanly

```shell
$ mvn dependency:tree | grep jackson-core -B 10
...
[INFO] +- io.debezium:debezium-core:jar:2.7.4.Final:compile
[INFO] |  +- io.debezium:debezium-api:jar:2.7.4.Final:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.21.1:compile
```