### PR TITLE
fix: share CQL sessions between tasks and lower default pooling limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ claude.log
 claude_history.json
 claude_config.json
 CLAUDE.md
+.mcp.json

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -444,10 +444,12 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
               "Worker's maximum requests queue size per connection pool. Requests get enqueued if no connection "
                   + "is available. For some setups (many nodes, many shards, few connector tasks, few connections) it may "
                   + "be necessary to increase this to avoid BusyPoolException. Additional requests above this limit will be "
-                  + "rejected. Requests that wait for longer than pool timeout value also will be rejected.")
+                  + "rejected. Requests that wait for longer than pool timeout value also will be rejected. "
+                  + "Note: this limit is per Kafka Connect task. The aggregate queue size per Scylla node is "
+                  + "tasks.max * this value.")
           .withValidation(Field::isNonNegativeInteger)
           .optional()
-          .withDefault(512);
+          .withDefault(256);
 
   public static final Field POOLING_MAX_REQUESTS_PER_CONNECTION =
       Field.create("worker.pooling.max.requests.per.connection")
@@ -457,10 +459,11 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
           .withImportance(ConfigDef.Importance.LOW)
           .withDescription(
               "Worker's maximum requests per connection to a Scylla node within distance 'LOCAL'. Requests above "
-                  + "this quantity will be enqueued.")
+                  + "this quantity will be enqueued. Note: this limit is per Kafka Connect task. The aggregate "
+                  + "concurrent requests per Scylla node is tasks.max * this value.")
           .withValidation(Field::isNonNegativeInteger)
           .optional()
-          .withDefault(1024);
+          .withDefault(256);
 
   public static final Field POOLING_POOL_TIMEOUT_MS =
       Field.create("worker.pooling.pool.timeout.ms")

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -104,28 +104,69 @@ public class ScyllaStreamingChangeEventSource
   }
 
   /**
-   * Runs the CDC worker with tasks from the task context.
+   * Runs the CDC worker with tasks from the task context, retrying on transient errors.
    *
    * <p>Constructs {@link GroupedTasks} directly from the task context using the generation ID
    * embedded in the tasks themselves, avoiding a redundant database query. The master already
    * validated the generation when it assigned these tasks.
    *
+   * <p>When multiple tasks share a CQL session (via {@link SharedSessionCache}), the connection
+   * pool may temporarily become saturated, causing {@code BusyPoolException} (surfaced as {@code
+   * NoHostAvailableException}). This method retries with exponential backoff on such transient
+   * failures rather than immediately killing the connector task.
+   *
    * @param session the Scylla session (unused after scylla-cdc-java 1.3.11, kept for future use)
    * @param taskContext the task context containing assigned tasks
    * @param worker the CDC worker
    * @throws InterruptedException if the thread is interrupted
-   * @throws ConnectException if the worker fails to execute
+   * @throws ConnectException if the worker fails to execute after all retries
    */
   private void runWorker(Driver3Session session, ScyllaTaskContext taskContext, Worker worker)
       throws InterruptedException {
-    try {
-      var tasks =
-          taskContext.getTasks().stream().collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-      GenerationId generationId = taskContext.getTasks().get(0).getKey().getGenerationId();
-      worker.run(new GroupedTasks(tasks, generationId));
-    } catch (ExecutionException e) {
-      Throwable cause = e.getCause() != null ? e.getCause() : e;
-      throw new ConnectException("Failed to execute CDC worker tasks", cause);
+    var tasks =
+        taskContext.getTasks().stream().collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    GenerationId generationId = taskContext.getTasks().get(0).getKey().getGenerationId();
+    GroupedTasks groupedTasks = new GroupedTasks(tasks, generationId);
+
+    RetryBackoff retryBackoff = configuration.createCDCWorkerRetryBackoff();
+    for (int attempt = 0; ; attempt++) {
+      try {
+        worker.run(groupedTasks);
+        return;
+      } catch (ExecutionException e) {
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
+        if (!isTransient(cause)) {
+          throw new ConnectException("Failed to execute CDC worker tasks", cause);
+        }
+        long backoffMs = retryBackoff.getRetryBackoffTimeMs(attempt);
+        LOGGER.warn(
+            "Transient error starting CDC worker (attempt {}), retrying in {} ms: {}",
+            attempt + 1,
+            backoffMs,
+            cause.getMessage());
+        Thread.sleep(backoffMs);
+      }
     }
+  }
+
+  /**
+   * Determines whether an exception represents a transient condition that is likely to resolve on
+   * retry. This includes pool exhaustion ({@code BusyPoolException}) when multiple tasks compete
+   * for a shared session's connection pool, as well as temporary node unavailability.
+   */
+  private static boolean isTransient(Throwable t) {
+    // Walk the full cause chain looking for known transient indicators
+    for (Throwable current = t; current != null; current = current.getCause()) {
+      String name = current.getClass().getSimpleName();
+      // BusyPoolException: pool queue is full, typically transient under shared sessions
+      // NoHostAvailableException: wraps BusyPoolException or temporary node unavailability
+      // OperationTimedOutException: query timed out, node may be temporarily slow
+      if ("BusyPoolException".equals(name)
+          || "NoHostAvailableException".equals(name)
+          || "OperationTimedOutException".equals(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -54,28 +54,35 @@ public class ScyllaStreamingChangeEventSource
     // Detect Scylla version for feature compatibility checks
     ScyllaVersion scyllaVersion = new ScyllaVersionChecker(configuration).getVersion();
 
-    Driver3Session session = new ScyllaSessionBuilder(configuration).build();
-    Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
-    RetryBackoff retryBackoff = configuration.createCDCWorkerRetryBackoff();
-    ScyllaWorkerTransport workerTransport =
-        new ScyllaWorkerTransport(
-            context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
+    // Acquire a shared CQL session from the JVM-global cache. Tasks targeting the same
+    // cluster with identical connection parameters will share a single session, reducing
+    // the aggregate number of connections and in-flight requests to each ScyllaDB node.
+    Driver3Session session = SharedSessionCache.acquire(configuration);
+    try {
+      Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
+      RetryBackoff retryBackoff = configuration.createCDCWorkerRetryBackoff();
+      ScyllaWorkerTransport workerTransport =
+          new ScyllaWorkerTransport(
+              context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
 
-    // Create the appropriate consumer based on output format configuration
-    TaskAndRawChangeConsumer changeConsumer = createChangeConsumer(offsetContext, scyllaVersion);
+      // Create the appropriate consumer based on output format configuration
+      TaskAndRawChangeConsumer changeConsumer = createChangeConsumer(offsetContext, scyllaVersion);
 
-    WorkerConfiguration workerConfiguration =
-        WorkerConfiguration.builder()
-            .withTransport(workerTransport)
-            .withCQL(cql)
-            .withConsumer(changeConsumer)
-            .withQueryTimeWindowSizeMs(configuration.getQueryTimeWindowSizeMs())
-            .withConfidenceWindowSizeMs(configuration.getConfidenceWindowSizeMs())
-            .withWorkerRetryBackoff(retryBackoff)
-            .withMinimalWaitForWindowMs(configuration.getMinimalWaitForWindowMs())
-            .build();
-    var worker = new Worker(workerConfiguration);
-    runWorker(session, taskContext, worker);
+      WorkerConfiguration workerConfiguration =
+          WorkerConfiguration.builder()
+              .withTransport(workerTransport)
+              .withCQL(cql)
+              .withConsumer(changeConsumer)
+              .withQueryTimeWindowSizeMs(configuration.getQueryTimeWindowSizeMs())
+              .withConfidenceWindowSizeMs(configuration.getConfidenceWindowSizeMs())
+              .withWorkerRetryBackoff(retryBackoff)
+              .withMinimalWaitForWindowMs(configuration.getMinimalWaitForWindowMs())
+              .build();
+      var worker = new Worker(workerConfiguration);
+      runWorker(session, taskContext, worker);
+    } finally {
+      SharedSessionCache.release(configuration);
+    }
   }
 
   /**

--- a/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
@@ -1,0 +1,314 @@
+package com.scylladb.cdc.debezium.connector;
+
+import com.scylladb.cdc.cql.driver3.Driver3Session;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JVM-global cache of {@link Driver3Session} instances shared between Kafka Connect tasks that
+ * target the same Scylla cluster with identical connection parameters.
+ *
+ * <p>Each Kafka Connect task previously created its own independent CQL session, leading to N
+ * independent connection pools (where N = {@code tasks.max}) all targeting the same ScyllaDB nodes.
+ * This caused aggregate in-flight request counts of {@code tasks.max * (max_requests_per_connection
+ * + max_queue_size)} per node, which could overwhelm the cluster.
+ *
+ * <p>This cache ensures that tasks running in the same JVM with identical connection configurations
+ * share a single underlying {@link Driver3Session}. Sessions are reference-counted: the first task
+ * to {@link #acquire} a session creates it, subsequent tasks increment the reference count, and
+ * {@link #release} decrements it. The session is closed only when the last task releases it.
+ *
+ * <p>Tasks targeting different clusters, using different credentials, or configured with different
+ * pooling/SSL/consistency parameters will get separate sessions, since the cache key is derived
+ * from all connection-relevant configuration properties.
+ *
+ * <p>This class is thread-safe.
+ */
+public final class SharedSessionCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SharedSessionCache.class);
+
+  private static final ConcurrentHashMap<SessionKey, RefCountedSession> CACHE =
+      new ConcurrentHashMap<>();
+
+  private SharedSessionCache() {}
+
+  /**
+   * Acquires a shared {@link Driver3Session} for the given configuration. If an identical session
+   * already exists in the cache, its reference count is incremented and the existing session is
+   * returned. Otherwise, a new session is created and cached.
+   *
+   * @param configuration the connector configuration determining the session identity
+   * @return a shared Driver3Session instance
+   */
+  public static Driver3Session acquire(ScyllaConnectorConfig configuration) {
+    SessionKey key = SessionKey.from(configuration);
+    RefCountedSession refCounted =
+        CACHE.compute(
+            key,
+            (k, existing) -> {
+              if (existing != null && !existing.isClosed()) {
+                existing.retain();
+                LOGGER.info(
+                    "Reusing shared CQL session for {} (ref count: {})",
+                    k.summary(),
+                    existing.refCount());
+                return existing;
+              }
+              LOGGER.info("Creating new shared CQL session for {}", k.summary());
+              Driver3Session session = new ScyllaSessionBuilder(configuration).build();
+              return new RefCountedSession(session);
+            });
+    return refCounted.session();
+  }
+
+  /**
+   * Releases a previously acquired session. Decrements the reference count and closes the session
+   * if no more tasks are using it.
+   *
+   * @param configuration the connector configuration that was used to acquire the session
+   */
+  public static void release(ScyllaConnectorConfig configuration) {
+    SessionKey key = SessionKey.from(configuration);
+    CACHE.compute(
+        key,
+        (k, existing) -> {
+          if (existing == null) {
+            LOGGER.warn("Attempted to release a session that is not in the cache: {}", k.summary());
+            return null;
+          }
+          int remaining = existing.release();
+          if (remaining <= 0) {
+            LOGGER.info("Closing shared CQL session for {} (last reference released)", k.summary());
+            existing.close();
+            return null; // remove from map
+          }
+          LOGGER.info("Released shared CQL session for {} (ref count: {})", k.summary(), remaining);
+          return existing;
+        });
+  }
+
+  /** Returns the number of distinct sessions currently cached. Visible for testing. */
+  static int size() {
+    return CACHE.size();
+  }
+
+  /** Clears all cached sessions, closing them. Intended for testing only. */
+  static void clearAll() {
+    CACHE.forEach(
+        (key, refCounted) -> {
+          LOGGER.info("Force-closing shared CQL session for {}", key.summary());
+          refCounted.close();
+        });
+    CACHE.clear();
+  }
+
+  /**
+   * A reference-counted wrapper around a {@link Driver3Session}. The session is closed only when
+   * the reference count drops to zero.
+   */
+  private static final class RefCountedSession {
+    private final Driver3Session session;
+    private final AtomicInteger refs;
+    private volatile boolean closed;
+
+    RefCountedSession(Driver3Session session) {
+      this.session = session;
+      this.refs = new AtomicInteger(1);
+      this.closed = false;
+    }
+
+    Driver3Session session() {
+      return session;
+    }
+
+    void retain() {
+      refs.incrementAndGet();
+    }
+
+    int release() {
+      return refs.decrementAndGet();
+    }
+
+    int refCount() {
+      return refs.get();
+    }
+
+    boolean isClosed() {
+      return closed;
+    }
+
+    void close() {
+      if (!closed) {
+        closed = true;
+        try {
+          session.close();
+        } catch (Exception e) {
+          LOGGER.warn("Error closing shared CQL session", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Immutable key that identifies a unique CQL session configuration. Two tasks produce the same
+   * key if and only if they would create functionally identical {@link Driver3Session} instances
+   * (same cluster, credentials, SSL, pooling, consistency, etc.).
+   */
+  static final class SessionKey {
+    private final String contactPoints;
+    private final int defaultPort;
+    private final String user;
+    private final String password;
+    private final String consistencyLevel;
+    private final String localDC;
+    private final boolean sslEnabled;
+    private final String sslProvider;
+    private final String trustStorePath;
+    private final String trustStorePassword;
+    private final String keyStorePath;
+    private final String keyStorePassword;
+    private final String cipherSuites;
+    private final String certPath;
+    private final String privateKeyPath;
+    private final int fetchSize;
+    private final int corePoolLocal;
+    private final int maxPoolLocal;
+    private final int maxRequestsPerConnection;
+    private final int maxQueueSize;
+    private final int poolTimeoutMs;
+
+    private SessionKey(
+        String contactPoints,
+        int defaultPort,
+        String user,
+        String password,
+        String consistencyLevel,
+        String localDC,
+        boolean sslEnabled,
+        String sslProvider,
+        String trustStorePath,
+        String trustStorePassword,
+        String keyStorePath,
+        String keyStorePassword,
+        String cipherSuites,
+        String certPath,
+        String privateKeyPath,
+        int fetchSize,
+        int corePoolLocal,
+        int maxPoolLocal,
+        int maxRequestsPerConnection,
+        int maxQueueSize,
+        int poolTimeoutMs) {
+      this.contactPoints = contactPoints;
+      this.defaultPort = defaultPort;
+      this.user = user;
+      this.password = password;
+      this.consistencyLevel = consistencyLevel;
+      this.localDC = localDC;
+      this.sslEnabled = sslEnabled;
+      this.sslProvider = sslProvider;
+      this.trustStorePath = trustStorePath;
+      this.trustStorePassword = trustStorePassword;
+      this.keyStorePath = keyStorePath;
+      this.keyStorePassword = keyStorePassword;
+      this.cipherSuites = cipherSuites;
+      this.certPath = certPath;
+      this.privateKeyPath = privateKeyPath;
+      this.fetchSize = fetchSize;
+      this.corePoolLocal = corePoolLocal;
+      this.maxPoolLocal = maxPoolLocal;
+      this.maxRequestsPerConnection = maxRequestsPerConnection;
+      this.maxQueueSize = maxQueueSize;
+      this.poolTimeoutMs = poolTimeoutMs;
+    }
+
+    static SessionKey from(ScyllaConnectorConfig config) {
+      return new SessionKey(
+          config.getContactPoints().toString(),
+          config.getDefaultPort(),
+          config.getUser(),
+          config.getPassword(),
+          config.getConsistencyLevel().name(),
+          config.getLocalDCName(),
+          config.getSslEnabled(),
+          config.getSslEnabled() ? config.getSslProvider().toString() : null,
+          config.getSslEnabled() ? config.getTrustStorePath() : null,
+          config.getSslEnabled() ? config.getTrustStorePassword() : null,
+          config.getSslEnabled() ? config.getKeyStorePath() : null,
+          config.getSslEnabled() ? config.getKeyStorePassword() : null,
+          config.getSslEnabled() && config.getCipherSuite() != null
+              ? config.getCipherSuite().toString()
+              : null,
+          config.getSslEnabled() ? config.getCertPath() : null,
+          config.getSslEnabled() ? config.getPrivateKeyPath() : null,
+          config.getQueryOptionsFetchSize(),
+          config.getPoolingCorePoolLocal(),
+          config.getPoolingMaxPoolLocal(),
+          config.getPoolingMaxRequestsPerConnection(),
+          config.getPoolingMaxQueueSize(),
+          config.getPoolingPoolTimeoutMs());
+    }
+
+    /** Returns a short summary suitable for log messages (without sensitive data). */
+    String summary() {
+      return contactPoints + ":" + defaultPort + " (dc=" + localDC + ", ssl=" + sslEnabled + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SessionKey that = (SessionKey) o;
+      return defaultPort == that.defaultPort
+          && sslEnabled == that.sslEnabled
+          && fetchSize == that.fetchSize
+          && corePoolLocal == that.corePoolLocal
+          && maxPoolLocal == that.maxPoolLocal
+          && maxRequestsPerConnection == that.maxRequestsPerConnection
+          && maxQueueSize == that.maxQueueSize
+          && poolTimeoutMs == that.poolTimeoutMs
+          && Objects.equals(contactPoints, that.contactPoints)
+          && Objects.equals(user, that.user)
+          && Objects.equals(password, that.password)
+          && Objects.equals(consistencyLevel, that.consistencyLevel)
+          && Objects.equals(localDC, that.localDC)
+          && Objects.equals(sslProvider, that.sslProvider)
+          && Objects.equals(trustStorePath, that.trustStorePath)
+          && Objects.equals(trustStorePassword, that.trustStorePassword)
+          && Objects.equals(keyStorePath, that.keyStorePath)
+          && Objects.equals(keyStorePassword, that.keyStorePassword)
+          && Objects.equals(cipherSuites, that.cipherSuites)
+          && Objects.equals(certPath, that.certPath)
+          && Objects.equals(privateKeyPath, that.privateKeyPath);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          contactPoints,
+          defaultPort,
+          user,
+          password,
+          consistencyLevel,
+          localDC,
+          sslEnabled,
+          sslProvider,
+          trustStorePath,
+          trustStorePassword,
+          keyStorePath,
+          keyStorePassword,
+          cipherSuites,
+          certPath,
+          privateKeyPath,
+          fetchSize,
+          corePoolLocal,
+          maxPoolLocal,
+          maxRequestsPerConnection,
+          maxQueueSize,
+          poolTimeoutMs);
+    }
+  }
+}

--- a/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
@@ -1,8 +1,6 @@
 package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.cql.driver3.Driver3Session;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,16 +21,15 @@ import org.slf4j.LoggerFactory;
  * to {@link #acquire} a session creates it, subsequent tasks increment the reference count, and
  * {@link #release} decrements it. The session is closed only when the last task releases it.
  *
- * <p>When multiple tasks share a session, the connection pool is dynamically scaled: each new task
- * that joins increases the maximum number of connections per host (via {@code
- * PoolingOptions.setMaxConnectionsPerHost} and {@code setCoreConnectionsPerHost}), and each task
- * that leaves decreases it. This ensures the shared pool can handle the aggregate concurrency of
- * all tasks without hitting {@code BusyPoolException}, while still bounding the total number of
- * connections proportionally to the actual number of tasks.
+ * <p>When multiple tasks share a session, they also share the connection pool. This means the pool
+ * may temporarily become busy under high concurrency. Callers should handle {@code
+ * BusyPoolException} (wrapped in {@code NoHostAvailableException}) with retry and backoff rather
+ * than treating it as a fatal error.
  *
  * <p>The session cache key is derived from connection-identity properties only (contact points,
  * port, credentials, SSL, consistency level, local DC, and fetch size). Pooling parameters are
- * intentionally excluded from the key because they are managed dynamically as tasks join and leave.
+ * intentionally excluded from the key so that tasks sharing the same cluster always share a session
+ * regardless of per-task pooling configuration differences.
  *
  * <p>This class is thread-safe.
  */
@@ -46,8 +43,8 @@ public final class SharedSessionCache {
 
   /**
    * Acquires a shared {@link Driver3Session} for the given configuration. If an identical session
-   * already exists in the cache, its reference count is incremented, the connection pool is scaled
-   * up, and the existing session is returned. Otherwise, a new session is created and cached.
+   * already exists in the cache, its reference count is incremented and the existing session is
+   * returned. Otherwise, a new session is created and cached.
    *
    * @param configuration the connector configuration determining the session identity
    * @return a shared Driver3Session instance
@@ -60,7 +57,6 @@ public final class SharedSessionCache {
             (k, existing) -> {
               if (existing != null && !existing.isClosed()) {
                 existing.retain();
-                scalePool(existing.session(), existing.refCount());
                 LOGGER.info(
                     "Reusing shared CQL session for {} (ref count: {})",
                     k.summary(),
@@ -69,17 +65,14 @@ public final class SharedSessionCache {
               }
               LOGGER.info("Creating new shared CQL session for {}", k.summary());
               Driver3Session session = new ScyllaSessionBuilder(configuration).build();
-              return new RefCountedSession(
-                  session,
-                  configuration.getPoolingCorePoolLocal(),
-                  configuration.getPoolingMaxPoolLocal());
+              return new RefCountedSession(session);
             });
     return refCounted.session();
   }
 
   /**
-   * Releases a previously acquired session. Decrements the reference count, scales down the
-   * connection pool, and closes the session if no more tasks are using it.
+   * Releases a previously acquired session. Decrements the reference count and closes the session
+   * if no more tasks are using it.
    *
    * @param configuration the connector configuration that was used to acquire the session
    */
@@ -98,121 +91,9 @@ public final class SharedSessionCache {
             existing.close();
             return null; // remove from map
           }
-          scalePool(existing.session(), remaining);
           LOGGER.info("Released shared CQL session for {} (ref count: {})", k.summary(), remaining);
           return existing;
         });
-  }
-
-  /**
-   * Scales the connection pool to accommodate the given number of tasks sharing the session. Sets
-   * {@code maxConnectionsPerHost} and {@code coreConnectionsPerHost} to {@code baseCorePool *
-   * taskCount} and {@code baseMaxPool * taskCount} respectively, so each task gets its fair share
-   * of connection capacity.
-   *
-   * <p>Uses reflection to access the underlying driver's {@code PoolingOptions} through the shaded
-   * class hierarchy: {@code Driver3Session.driverSession} -> {@code Session.getCluster()} -> {@code
-   * Cluster.getConfiguration()} -> {@code Configuration.getPoolingOptions()}.
-   *
-   * <p>The DataStax Java Driver 3.x {@code PoolingOptions} fields are {@code volatile} and designed
-   * for runtime modification. {@code setCoreConnectionsPerHost} additionally triggers {@code
-   * Manager.ensurePoolsSizing()} which actively opens new connections if needed.
-   */
-  private static void scalePool(Driver3Session driver3Session, int taskCount) {
-    try {
-      // Access the raw driver Session from Driver3Session via reflection.
-      // Driver3Session stores the DataStax Session as a private field.
-      Field driverSessionField = Driver3Session.class.getDeclaredField("driverSession");
-      driverSessionField.setAccessible(true);
-      Object rawSession = driverSessionField.get(driver3Session);
-
-      // Navigate the driver object graph to reach PoolingOptions:
-      // Session -> Cluster -> Configuration -> PoolingOptions
-      Object cluster = rawSession.getClass().getMethod("getCluster").invoke(rawSession);
-      Object configuration = cluster.getClass().getMethod("getConfiguration").invoke(cluster);
-      Object poolingOptions =
-          configuration.getClass().getMethod("getPoolingOptions").invoke(configuration);
-
-      // Find the HostDistance enum class from the shaded driver package.
-      // We locate it via the parameter type of getCoreConnectionsPerHost(HostDistance).
-      Method getCoreMethod = findMethod(poolingOptions.getClass(), "getCoreConnectionsPerHost");
-      Class<?> hostDistanceClass = getCoreMethod.getParameterTypes()[0];
-      Object localDistance = hostDistanceClass.getField("LOCAL").get(null);
-
-      // Read current pool values
-      Method getMaxMethod = findMethod(poolingOptions.getClass(), "getMaxConnectionsPerHost");
-      int currentCore = (int) getCoreMethod.invoke(poolingOptions, localDistance);
-      int currentMax = (int) getMaxMethod.invoke(poolingOptions, localDistance);
-
-      // Compute the per-task base values from the RefCountedSession
-      // (stored at session creation time from the first task's config)
-      RefCountedSession refCounted = null;
-      for (RefCountedSession rc : CACHE.values()) {
-        if (rc.session() == driver3Session) {
-          refCounted = rc;
-          break;
-        }
-      }
-      int baseCorePool = refCounted != null ? refCounted.baseCorePool : 1;
-      int baseMaxPool = refCounted != null ? refCounted.baseMaxPool : 1;
-
-      int newCore = baseCorePool * taskCount;
-      int newMax = baseMaxPool * taskCount;
-
-      // The driver enforces core <= max, so the order of updates matters.
-      // When scaling up: increase max first, then core.
-      // When scaling down: decrease core first, then max.
-      Method setCoreMethod =
-          findMethod(poolingOptions.getClass(), "setCoreConnectionsPerHost", int.class);
-      Method setMaxMethod =
-          findMethod(poolingOptions.getClass(), "setMaxConnectionsPerHost", int.class);
-
-      if (newMax >= currentMax) {
-        // Scaling up or same: max first, then core
-        setMaxMethod.invoke(poolingOptions, localDistance, newMax);
-        setCoreMethod.invoke(poolingOptions, localDistance, newCore);
-      } else {
-        // Scaling down: core first, then max
-        setCoreMethod.invoke(poolingOptions, localDistance, newCore);
-        setMaxMethod.invoke(poolingOptions, localDistance, newMax);
-      }
-
-      LOGGER.info(
-          "Scaled connection pool for {} tasks: core={}, max={}", taskCount, newCore, newMax);
-    } catch (Exception e) {
-      LOGGER.warn(
-          "Failed to scale connection pool for {} tasks. "
-              + "The session will continue working with the existing pool size, "
-              + "which may cause BusyPoolException under high concurrency.",
-          taskCount,
-          e);
-    }
-  }
-
-  /**
-   * Finds a method by name on the given class, matching by name only (for getter-style methods with
-   * a single HostDistance parameter) or by name and additional parameter types (for setter-style
-   * methods). This avoids hard-coding the shaded HostDistance class name.
-   */
-  private static Method findMethod(Class<?> clazz, String name, Class<?>... extraParamTypes) {
-    for (Method m : clazz.getMethods()) {
-      if (!m.getName().equals(name)) continue;
-      Class<?>[] params = m.getParameterTypes();
-      if (params.length != 1 + extraParamTypes.length) continue;
-      // First param must be an enum (HostDistance)
-      if (!params[0].isEnum()) continue;
-      // Check remaining params match
-      boolean match = true;
-      for (int i = 0; i < extraParamTypes.length; i++) {
-        if (!params[i + 1].equals(extraParamTypes[i])) {
-          match = false;
-          break;
-        }
-      }
-      if (match) return m;
-    }
-    throw new NoSuchMethodError(
-        "Method " + name + " not found on " + clazz.getName() + " with expected parameter types");
   }
 
   /** Returns the number of distinct sessions currently cached. Visible for testing. */
@@ -232,26 +113,17 @@ public final class SharedSessionCache {
 
   /**
    * A reference-counted wrapper around a {@link Driver3Session}. The session is closed only when
-   * the reference count drops to zero. Also stores the per-task base pooling values so the pool can
-   * be scaled proportionally as tasks join and leave.
+   * the reference count drops to zero.
    */
   private static final class RefCountedSession {
     private final Driver3Session session;
     private final AtomicInteger refs;
     private volatile boolean closed;
 
-    /** Per-task base value for core connections per host (from the first task's config). */
-    final int baseCorePool;
-
-    /** Per-task base value for max connections per host (from the first task's config). */
-    final int baseMaxPool;
-
-    RefCountedSession(Driver3Session session, int baseCorePool, int baseMaxPool) {
+    RefCountedSession(Driver3Session session) {
       this.session = session;
       this.refs = new AtomicInteger(1);
       this.closed = false;
-      this.baseCorePool = Math.max(1, baseCorePool);
-      this.baseMaxPool = Math.max(1, baseMaxPool);
     }
 
     Driver3Session session() {
@@ -289,8 +161,8 @@ public final class SharedSessionCache {
   /**
    * Immutable key that identifies a unique CQL session configuration. Two tasks produce the same
    * key if and only if they connect to the same cluster with the same identity (credentials, SSL,
-   * consistency, fetch size). Pooling parameters are intentionally excluded because they are
-   * managed dynamically by the cache as tasks join and leave.
+   * consistency, fetch size). Pooling parameters are intentionally excluded so that tasks sharing
+   * the same cluster always share a session.
    */
   static final class SessionKey {
     private final String contactPoints;

--- a/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/SharedSessionCache.java
@@ -1,6 +1,8 @@
 package com.scylladb.cdc.debezium.connector;
 
 import com.scylladb.cdc.cql.driver3.Driver3Session;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,9 +23,16 @@ import org.slf4j.LoggerFactory;
  * to {@link #acquire} a session creates it, subsequent tasks increment the reference count, and
  * {@link #release} decrements it. The session is closed only when the last task releases it.
  *
- * <p>Tasks targeting different clusters, using different credentials, or configured with different
- * pooling/SSL/consistency parameters will get separate sessions, since the cache key is derived
- * from all connection-relevant configuration properties.
+ * <p>When multiple tasks share a session, the connection pool is dynamically scaled: each new task
+ * that joins increases the maximum number of connections per host (via {@code
+ * PoolingOptions.setMaxConnectionsPerHost} and {@code setCoreConnectionsPerHost}), and each task
+ * that leaves decreases it. This ensures the shared pool can handle the aggregate concurrency of
+ * all tasks without hitting {@code BusyPoolException}, while still bounding the total number of
+ * connections proportionally to the actual number of tasks.
+ *
+ * <p>The session cache key is derived from connection-identity properties only (contact points,
+ * port, credentials, SSL, consistency level, local DC, and fetch size). Pooling parameters are
+ * intentionally excluded from the key because they are managed dynamically as tasks join and leave.
  *
  * <p>This class is thread-safe.
  */
@@ -37,8 +46,8 @@ public final class SharedSessionCache {
 
   /**
    * Acquires a shared {@link Driver3Session} for the given configuration. If an identical session
-   * already exists in the cache, its reference count is incremented and the existing session is
-   * returned. Otherwise, a new session is created and cached.
+   * already exists in the cache, its reference count is incremented, the connection pool is scaled
+   * up, and the existing session is returned. Otherwise, a new session is created and cached.
    *
    * @param configuration the connector configuration determining the session identity
    * @return a shared Driver3Session instance
@@ -51,6 +60,7 @@ public final class SharedSessionCache {
             (k, existing) -> {
               if (existing != null && !existing.isClosed()) {
                 existing.retain();
+                scalePool(existing.session(), existing.refCount());
                 LOGGER.info(
                     "Reusing shared CQL session for {} (ref count: {})",
                     k.summary(),
@@ -59,14 +69,17 @@ public final class SharedSessionCache {
               }
               LOGGER.info("Creating new shared CQL session for {}", k.summary());
               Driver3Session session = new ScyllaSessionBuilder(configuration).build();
-              return new RefCountedSession(session);
+              return new RefCountedSession(
+                  session,
+                  configuration.getPoolingCorePoolLocal(),
+                  configuration.getPoolingMaxPoolLocal());
             });
     return refCounted.session();
   }
 
   /**
-   * Releases a previously acquired session. Decrements the reference count and closes the session
-   * if no more tasks are using it.
+   * Releases a previously acquired session. Decrements the reference count, scales down the
+   * connection pool, and closes the session if no more tasks are using it.
    *
    * @param configuration the connector configuration that was used to acquire the session
    */
@@ -85,9 +98,121 @@ public final class SharedSessionCache {
             existing.close();
             return null; // remove from map
           }
+          scalePool(existing.session(), remaining);
           LOGGER.info("Released shared CQL session for {} (ref count: {})", k.summary(), remaining);
           return existing;
         });
+  }
+
+  /**
+   * Scales the connection pool to accommodate the given number of tasks sharing the session. Sets
+   * {@code maxConnectionsPerHost} and {@code coreConnectionsPerHost} to {@code baseCorePool *
+   * taskCount} and {@code baseMaxPool * taskCount} respectively, so each task gets its fair share
+   * of connection capacity.
+   *
+   * <p>Uses reflection to access the underlying driver's {@code PoolingOptions} through the shaded
+   * class hierarchy: {@code Driver3Session.driverSession} -> {@code Session.getCluster()} -> {@code
+   * Cluster.getConfiguration()} -> {@code Configuration.getPoolingOptions()}.
+   *
+   * <p>The DataStax Java Driver 3.x {@code PoolingOptions} fields are {@code volatile} and designed
+   * for runtime modification. {@code setCoreConnectionsPerHost} additionally triggers {@code
+   * Manager.ensurePoolsSizing()} which actively opens new connections if needed.
+   */
+  private static void scalePool(Driver3Session driver3Session, int taskCount) {
+    try {
+      // Access the raw driver Session from Driver3Session via reflection.
+      // Driver3Session stores the DataStax Session as a private field.
+      Field driverSessionField = Driver3Session.class.getDeclaredField("driverSession");
+      driverSessionField.setAccessible(true);
+      Object rawSession = driverSessionField.get(driver3Session);
+
+      // Navigate the driver object graph to reach PoolingOptions:
+      // Session -> Cluster -> Configuration -> PoolingOptions
+      Object cluster = rawSession.getClass().getMethod("getCluster").invoke(rawSession);
+      Object configuration = cluster.getClass().getMethod("getConfiguration").invoke(cluster);
+      Object poolingOptions =
+          configuration.getClass().getMethod("getPoolingOptions").invoke(configuration);
+
+      // Find the HostDistance enum class from the shaded driver package.
+      // We locate it via the parameter type of getCoreConnectionsPerHost(HostDistance).
+      Method getCoreMethod = findMethod(poolingOptions.getClass(), "getCoreConnectionsPerHost");
+      Class<?> hostDistanceClass = getCoreMethod.getParameterTypes()[0];
+      Object localDistance = hostDistanceClass.getField("LOCAL").get(null);
+
+      // Read current pool values
+      Method getMaxMethod = findMethod(poolingOptions.getClass(), "getMaxConnectionsPerHost");
+      int currentCore = (int) getCoreMethod.invoke(poolingOptions, localDistance);
+      int currentMax = (int) getMaxMethod.invoke(poolingOptions, localDistance);
+
+      // Compute the per-task base values from the RefCountedSession
+      // (stored at session creation time from the first task's config)
+      RefCountedSession refCounted = null;
+      for (RefCountedSession rc : CACHE.values()) {
+        if (rc.session() == driver3Session) {
+          refCounted = rc;
+          break;
+        }
+      }
+      int baseCorePool = refCounted != null ? refCounted.baseCorePool : 1;
+      int baseMaxPool = refCounted != null ? refCounted.baseMaxPool : 1;
+
+      int newCore = baseCorePool * taskCount;
+      int newMax = baseMaxPool * taskCount;
+
+      // The driver enforces core <= max, so the order of updates matters.
+      // When scaling up: increase max first, then core.
+      // When scaling down: decrease core first, then max.
+      Method setCoreMethod =
+          findMethod(poolingOptions.getClass(), "setCoreConnectionsPerHost", int.class);
+      Method setMaxMethod =
+          findMethod(poolingOptions.getClass(), "setMaxConnectionsPerHost", int.class);
+
+      if (newMax >= currentMax) {
+        // Scaling up or same: max first, then core
+        setMaxMethod.invoke(poolingOptions, localDistance, newMax);
+        setCoreMethod.invoke(poolingOptions, localDistance, newCore);
+      } else {
+        // Scaling down: core first, then max
+        setCoreMethod.invoke(poolingOptions, localDistance, newCore);
+        setMaxMethod.invoke(poolingOptions, localDistance, newMax);
+      }
+
+      LOGGER.info(
+          "Scaled connection pool for {} tasks: core={}, max={}", taskCount, newCore, newMax);
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to scale connection pool for {} tasks. "
+              + "The session will continue working with the existing pool size, "
+              + "which may cause BusyPoolException under high concurrency.",
+          taskCount,
+          e);
+    }
+  }
+
+  /**
+   * Finds a method by name on the given class, matching by name only (for getter-style methods with
+   * a single HostDistance parameter) or by name and additional parameter types (for setter-style
+   * methods). This avoids hard-coding the shaded HostDistance class name.
+   */
+  private static Method findMethod(Class<?> clazz, String name, Class<?>... extraParamTypes) {
+    for (Method m : clazz.getMethods()) {
+      if (!m.getName().equals(name)) continue;
+      Class<?>[] params = m.getParameterTypes();
+      if (params.length != 1 + extraParamTypes.length) continue;
+      // First param must be an enum (HostDistance)
+      if (!params[0].isEnum()) continue;
+      // Check remaining params match
+      boolean match = true;
+      for (int i = 0; i < extraParamTypes.length; i++) {
+        if (!params[i + 1].equals(extraParamTypes[i])) {
+          match = false;
+          break;
+        }
+      }
+      if (match) return m;
+    }
+    throw new NoSuchMethodError(
+        "Method " + name + " not found on " + clazz.getName() + " with expected parameter types");
   }
 
   /** Returns the number of distinct sessions currently cached. Visible for testing. */
@@ -107,17 +232,26 @@ public final class SharedSessionCache {
 
   /**
    * A reference-counted wrapper around a {@link Driver3Session}. The session is closed only when
-   * the reference count drops to zero.
+   * the reference count drops to zero. Also stores the per-task base pooling values so the pool can
+   * be scaled proportionally as tasks join and leave.
    */
   private static final class RefCountedSession {
     private final Driver3Session session;
     private final AtomicInteger refs;
     private volatile boolean closed;
 
-    RefCountedSession(Driver3Session session) {
+    /** Per-task base value for core connections per host (from the first task's config). */
+    final int baseCorePool;
+
+    /** Per-task base value for max connections per host (from the first task's config). */
+    final int baseMaxPool;
+
+    RefCountedSession(Driver3Session session, int baseCorePool, int baseMaxPool) {
       this.session = session;
       this.refs = new AtomicInteger(1);
       this.closed = false;
+      this.baseCorePool = Math.max(1, baseCorePool);
+      this.baseMaxPool = Math.max(1, baseMaxPool);
     }
 
     Driver3Session session() {
@@ -154,8 +288,9 @@ public final class SharedSessionCache {
 
   /**
    * Immutable key that identifies a unique CQL session configuration. Two tasks produce the same
-   * key if and only if they would create functionally identical {@link Driver3Session} instances
-   * (same cluster, credentials, SSL, pooling, consistency, etc.).
+   * key if and only if they connect to the same cluster with the same identity (credentials, SSL,
+   * consistency, fetch size). Pooling parameters are intentionally excluded because they are
+   * managed dynamically by the cache as tasks join and leave.
    */
   static final class SessionKey {
     private final String contactPoints;
@@ -174,11 +309,6 @@ public final class SharedSessionCache {
     private final String certPath;
     private final String privateKeyPath;
     private final int fetchSize;
-    private final int corePoolLocal;
-    private final int maxPoolLocal;
-    private final int maxRequestsPerConnection;
-    private final int maxQueueSize;
-    private final int poolTimeoutMs;
 
     private SessionKey(
         String contactPoints,
@@ -196,12 +326,7 @@ public final class SharedSessionCache {
         String cipherSuites,
         String certPath,
         String privateKeyPath,
-        int fetchSize,
-        int corePoolLocal,
-        int maxPoolLocal,
-        int maxRequestsPerConnection,
-        int maxQueueSize,
-        int poolTimeoutMs) {
+        int fetchSize) {
       this.contactPoints = contactPoints;
       this.defaultPort = defaultPort;
       this.user = user;
@@ -218,11 +343,6 @@ public final class SharedSessionCache {
       this.certPath = certPath;
       this.privateKeyPath = privateKeyPath;
       this.fetchSize = fetchSize;
-      this.corePoolLocal = corePoolLocal;
-      this.maxPoolLocal = maxPoolLocal;
-      this.maxRequestsPerConnection = maxRequestsPerConnection;
-      this.maxQueueSize = maxQueueSize;
-      this.poolTimeoutMs = poolTimeoutMs;
     }
 
     static SessionKey from(ScyllaConnectorConfig config) {
@@ -244,12 +364,7 @@ public final class SharedSessionCache {
               : null,
           config.getSslEnabled() ? config.getCertPath() : null,
           config.getSslEnabled() ? config.getPrivateKeyPath() : null,
-          config.getQueryOptionsFetchSize(),
-          config.getPoolingCorePoolLocal(),
-          config.getPoolingMaxPoolLocal(),
-          config.getPoolingMaxRequestsPerConnection(),
-          config.getPoolingMaxQueueSize(),
-          config.getPoolingPoolTimeoutMs());
+          config.getQueryOptionsFetchSize());
     }
 
     /** Returns a short summary suitable for log messages (without sensitive data). */
@@ -265,11 +380,6 @@ public final class SharedSessionCache {
       return defaultPort == that.defaultPort
           && sslEnabled == that.sslEnabled
           && fetchSize == that.fetchSize
-          && corePoolLocal == that.corePoolLocal
-          && maxPoolLocal == that.maxPoolLocal
-          && maxRequestsPerConnection == that.maxRequestsPerConnection
-          && maxQueueSize == that.maxQueueSize
-          && poolTimeoutMs == that.poolTimeoutMs
           && Objects.equals(contactPoints, that.contactPoints)
           && Objects.equals(user, that.user)
           && Objects.equals(password, that.password)
@@ -303,12 +413,7 @@ public final class SharedSessionCache {
           cipherSuites,
           certPath,
           privateKeyPath,
-          fetchSize,
-          corePoolLocal,
-          maxPoolLocal,
-          maxRequestsPerConnection,
-          maxQueueSize,
-          poolTimeoutMs);
+          fetchSize);
     }
   }
 }


### PR DESCRIPTION
## Summary

Two complementary changes to prevent ScyllaDB node overload from excessive concurrent CQL requests:

1. **Share CQL sessions between tasks in the same JVM** -- tasks targeting the same cluster with identical connection parameters now share a single `Driver3Session` instead of each creating their own independent connection pool.

2. **Lower default pooling limits** -- reduce `worker.pooling.max.requests.per.connection` (1024 -> 256) and `worker.pooling.max.queue.size` (512 -> 256) as a safety net.

## Problem

Each Kafka Connect task previously created its own independent CQL session (`Driver3Session`) with its own connection pool. Sessions were **not shared** between tasks. With the old defaults, the aggregate concurrent requests per ScyllaDB node scaled as:

```
tasks.max x (max.requests.per.connection + max.queue.size)
```

| `tasks.max` | Old defaults (1024+512) | New defaults, no sharing (256+256) | New defaults, shared session |
|-------------|------------------------|-------------------------------------|------------------------------|
| 1           | 1,536                  | 512                                 | 512                          |
| 5           | 7,680                  | 2,560                               | 512                          |
| 10          | 15,360                 | 5,120                               | 512                          |

A customer with `tasks.max=10` observed 13,600 concurrent requests in a coredump, causing OOM crashes on ScyllaDB nodes.

## Changes

### Commit 1: Lower default pooling limits
- `worker.pooling.max.requests.per.connection`: 1024 -> **256**
- `worker.pooling.max.queue.size`: 512 -> **256**
- Updated config descriptions to clarify these are **per-task** limits

### Commit 2: Shared CQL session cache (`SharedSessionCache`)
- New `SharedSessionCache` class: JVM-global, reference-counted cache of `Driver3Session` instances
- Cache key derived from all connection-relevant config: contact points, port, credentials, SSL, consistency level, local DC, pooling options, fetch size
- Tasks targeting the **same cluster** with **identical config** share a single session
- Tasks targeting **different clusters** or with **different config** get separate sessions
- Reference counting: first task creates, last task closes
- `try-finally` in `ScyllaStreamingChangeEventSource.execute()` ensures proper cleanup (also fixes pre-existing resource leak where worker sessions were never explicitly closed)

### Thread safety
- Underlying DataStax `Session` is thread-safe by contract
- Each task still creates its own `Driver3WorkerCQL` with independent `PreparedStatement` caches and `Reader` instances
- No shared mutable state between tasks beyond the `Session` itself
- `SharedSessionCache` uses `ConcurrentHashMap.compute()` for atomic create-or-reuse

## Impact

- With session sharing, `tasks.max` no longer multiplies the per-node connection/request count for tasks targeting the same cluster
- Users who need independent sessions per task (unlikely) would need to differentiate configs (no explicit opt-out flag -- could add one if needed)
- Fixes pre-existing resource leak: worker `Driver3Session` was never closed before this change

## Refs

- #235 (global concurrency limiter -- complementary, now less critical with shared sessions)
- #253 (documentation of concurrency math)