### PR TITLE
fix: lower default pooling limits to prevent node overload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ claude.log
 claude_history.json
 claude_config.json
 CLAUDE.md
+.mcp.json

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -444,10 +444,12 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
               "Worker's maximum requests queue size per connection pool. Requests get enqueued if no connection "
                   + "is available. For some setups (many nodes, many shards, few connector tasks, few connections) it may "
                   + "be necessary to increase this to avoid BusyPoolException. Additional requests above this limit will be "
-                  + "rejected. Requests that wait for longer than pool timeout value also will be rejected.")
+                  + "rejected. Requests that wait for longer than pool timeout value also will be rejected. "
+                  + "Note: this limit is per Kafka Connect task. The aggregate queue size per Scylla node is "
+                  + "tasks.max * this value.")
           .withValidation(Field::isNonNegativeInteger)
           .optional()
-          .withDefault(512);
+          .withDefault(256);
 
   public static final Field POOLING_MAX_REQUESTS_PER_CONNECTION =
       Field.create("worker.pooling.max.requests.per.connection")
@@ -457,10 +459,11 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
           .withImportance(ConfigDef.Importance.LOW)
           .withDescription(
               "Worker's maximum requests per connection to a Scylla node within distance 'LOCAL'. Requests above "
-                  + "this quantity will be enqueued.")
+                  + "this quantity will be enqueued. Note: this limit is per Kafka Connect task. The aggregate "
+                  + "concurrent requests per Scylla node is tasks.max * this value.")
           .withValidation(Field::isNonNegativeInteger)
           .optional()
-          .withDefault(1024);
+          .withDefault(256);
 
   public static final Field POOLING_POOL_TIMEOUT_MS =
       Field.create("worker.pooling.pool.timeout.ms")


### PR DESCRIPTION
## Summary

Lower the default values for `worker.pooling.max.requests.per.connection` (1024 → 256) and `worker.pooling.max.queue.size` (512 → 256) to reduce the risk of overwhelming ScyllaDB nodes with concurrent CDC log queries.

## Problem

Each Kafka Connect task creates its own independent CQL session with its own connection pool. The aggregate concurrent requests per ScyllaDB node scales as:

```
tasks.max × (max.requests.per.connection + max.queue.size)
```

With the previous defaults, a connector with `tasks.max=10` could generate up to **15,360** concurrent in-flight CQL requests to a single node, causing OOM crashes.

## Changes

- `worker.pooling.max.requests.per.connection`: 1024 → **256**
- `worker.pooling.max.queue.size`: 512 → **256**
- Updated config descriptions to clarify these are **per-task** limits

## Refs

- #235
- #253