### PR TITLE
feat: add ExampleOrderEventTransform SMT and custom transformations guide

### DIFF
--- a/docs/custom-transformations.md
+++ b/docs/custom-transformations.md
@@ -54,76 +54,194 @@ extra build steps or SPI registration are needed.
 
 ### Example: `ExampleOrderEventTransform`
 
-The class [`ExampleOrderEventTransform`][example-smt] ships with this connector as a reference
-implementation. It converts a CDC record for an `orders` table into a compact `OrderEvent` message
-on the topic `orders.order-event`.
+The class [`ExampleOrderEventTransform`][example-smt] ships with this connector as a
+production-realistic reference implementation. It models the following real-world requirements:
 
-#### What it does
+- Publish to a custom topic (`orders.order-event`) in an application-specific envelope format
+- Wrap every record in a metadata block + full row-snapshot payload
+- Derive domain event semantics (`ORDER_CREATED`, `ORDER_UPDATED`, `ORDER_DELETED`) from the CDC
+  operation type
+- Add four custom Kafka headers per message (`trace-id`, `schema-id`, `content-type`,
+  `event-source`)
+- Serialize as Protobuf (via the connector's `value.converter` — see
+  [Protobuf serialization](#protobuf-serialization) below)
 
-1. Drops tombstone (DELETE) records — returns `null` to suppress the record downstream.
-2. Reads five application-level fields from the upstream Struct (`order_id`, `customer_id`,
-   `status`, `total_amount`, `updated_at`).
-3. Emits a new record with a clean, flat schema and routes it to the configured target topic.
-4. Silently drops any CDC-internal or extra columns that are not part of the output schema.
+#### Output format
+
+Each record's value is a `Struct` with two nested blocks:
+
+```
+OrderEvent {
+  metadata {
+    event_id      String   — randomly generated UUID per message
+    event_name    String   — ORDER_CREATED / ORDER_UPDATED / ORDER_DELETED
+    entity_id     String   — copied from order_id (the domain entity key)
+    event_ts      Int64    — record timestamp in epoch milliseconds
+    state_impact  String   — INSERT / UPDATE / DELETE
+  }
+  payload {               — full Order row snapshot
+    order_id      String
+    customer_id   String
+    status        String
+    total_amount  Float64
+    updated_at    Int64
+  }
+}
+```
+
+#### Kafka headers
+
+Four headers are added to every message:
+
+| Header | Value |
+|--------|-------|
+| `trace-id` | UUID generated per message (propagate from upstream in real systems) |
+| `schema-id` | Fully-qualified output schema name (`com.example.orders.OrderEvent`) |
+| `content-type` | `application/x-protobuf` (informational; serialization is controlled by `value.converter`) |
+| `event-source` | Configurable string, default `scylla-cdc` |
+
+Headers are added by calling `record.headers().addString(key, value)` on the `ConnectRecord`
+returned by `newRecord()`. The `Headers` object is mutable; changes are visible to subsequent
+SMTs and to the Kafka producer.
+
+#### Operation type mapping
+
+The `__op` field is added by `ScyllaExtractNewRecordState` when configured with `add.fields=op`:
+
+| `__op` | `event_name` | `state_impact` |
+|--------|-------------|----------------|
+| `c` | `ORDER_CREATED` | `INSERT` |
+| `u` | `ORDER_UPDATED` | `UPDATE` |
+| `d` | `ORDER_DELETED` | `DELETE` |
+| _(absent)_ | `ORDER_UPDATED` | `UPDATE` |
+
+#### Full connector configuration
+
+```properties
+transforms=extractState,toOrderEvent
+
+# Unwrap Debezium envelope; expose CDC op type as __op field
+transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+transforms.extractState.cdc.output.format=advanced
+transforms.extractState.add.fields=op
+transforms.extractState.delete.tombstone.handling.mode=drop
+
+# Build the nested OrderEvent envelope with metadata + payload, add headers
+transforms.toOrderEvent.type=com.scylladb.cdc.debezium.connector.transforms.ExampleOrderEventTransform
+transforms.toOrderEvent.target.topic=orders.order-event
+transforms.toOrderEvent.event.source=my-service
+
+# Serialize as Protobuf (requires Confluent Schema Registry)
+value.converter=io.confluent.connect.protobuf.ProtobufConverter
+value.converter.schema.registry.url=http://schema-registry:8081
+```
+
+#### Transform chain order
+
+Transforms run left to right. `ScyllaExtractNewRecordState` must run first so that `__op` is
+promoted to a value field and Cell wrappers are stripped before the custom transform reads them:
+
+```
+raw CDC record (Debezium envelope)
+  → ScyllaExtractNewRecordState   (strips envelope, promotes __op, drops Cell wrappers)
+  → ExampleOrderEventTransform    (builds OrderEvent struct, adds Kafka headers)
+  → value.converter               (serializes Struct to Protobuf bytes)
+  → Kafka topic: orders.order-event
+```
 
 #### Step-by-step: adapting the example for your table
 
 1. **Copy and rename** `ExampleOrderEventTransform.java` — e.g. `ShipmentEventTransform.java`.
 
-2. **Update the field list** to match your table's columns:
+2. **Update the entity ID field** — set `ENTITY_ID_FIELD` to your table's primary key column:
    ```java
-   private static final String FIELD_SHIPMENT_ID   = "shipment_id";
-   private static final String FIELD_CARRIER        = "carrier";
-   private static final String FIELD_TRACKING_CODE  = "tracking_code";
+   private static final String ENTITY_ID_FIELD = "shipment_id";
    ```
 
-3. **Define the output schema**:
-   ```java
-   static final Schema OUTPUT_SCHEMA = SchemaBuilder.struct()
-           .name("com.example.shipping.ShipmentEvent")
-           .optional()
-           .field(FIELD_SHIPMENT_ID,  Schema.OPTIONAL_STRING_SCHEMA)
-           .field(FIELD_CARRIER,      Schema.OPTIONAL_STRING_SCHEMA)
-           .field(FIELD_TRACKING_CODE, Schema.OPTIONAL_STRING_SCHEMA)
-           .build();
-   ```
-
-4. **Override `buildOutputValue`** if you need computed fields or type coercions:
+3. **Update `event_name` prefix** — override `resolveEventName` / `resolveStateImpact`:
    ```java
    @Override
-   protected Struct buildOutputValue(Struct input) {
-       Struct output = new Struct(OUTPUT_SCHEMA);
-       output.put(FIELD_SHIPMENT_ID,  getOptionalField(input, FIELD_SHIPMENT_ID, String.class));
-       output.put(FIELD_CARRIER,      getOptionalField(input, FIELD_CARRIER, String.class));
-       // Computed: combine two source fields
-       String tracking = getOptionalField(input, "carrier_prefix", String.class);
-       String code     = getOptionalField(input, "shipment_number", String.class);
-       if (tracking != null && code != null) {
-           output.put(FIELD_TRACKING_CODE, tracking + "-" + code);
-       }
-       return output;
+   protected String resolveEventName(String op) {
+       if (OP_CREATE.equals(op)) return "SHIPMENT_CREATED";
+       if (OP_DELETE.equals(op)) return "SHIPMENT_DELETED";
+       return "SHIPMENT_UPDATED";
    }
    ```
 
-5. **Configure the connector** (runs the new SMT _after_ Cell unwrapping):
+4. **Update `PAYLOAD_SCHEMA` and `buildPayload`** to match your table's columns:
+   ```java
+   static final Schema PAYLOAD_SCHEMA = SchemaBuilder.struct()
+           .name("com.example.shipping.ShipmentEvent.Payload")
+           .optional()
+           .field("shipment_id",   Schema.OPTIONAL_STRING_SCHEMA)
+           .field("carrier",       Schema.OPTIONAL_STRING_SCHEMA)
+           .field("tracking_code", Schema.OPTIONAL_STRING_SCHEMA)
+           .build();
+
+   @Override
+   protected Struct buildPayload(Struct input) {
+       return new Struct(PAYLOAD_SCHEMA)
+               .put("shipment_id",   getOptionalField(input, "shipment_id",   String.class))
+               .put("carrier",       getOptionalField(input, "carrier",        String.class))
+               .put("tracking_code", getOptionalField(input, "tracking_code",  String.class));
+   }
+   ```
+
+5. **Update `SCHEMA_ID_VALUE`** to your Protobuf schema's fully-qualified name:
+   ```java
+   private static final String SCHEMA_ID_VALUE = "com.example.shipping.ShipmentEvent";
+   ```
+
+6. **Register the class name in the connector config**:
    ```properties
-   transforms=extractState,toShipmentEvent
-   transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
    transforms.toShipmentEvent.type=com.scylladb.cdc.debezium.connector.transforms.ShipmentEventTransform
    transforms.toShipmentEvent.target.topic=logistics.shipment-event
    ```
 
-#### Run transform chain order
+---
 
-Transforms run left to right. Always put `ScyllaExtractNewRecordState` (or equivalent) before your
-custom transform so that Cell wrappers are stripped first:
+## Protobuf serialization
 
+The SMT produces a Kafka Connect `Struct` — a schema-aware in-memory object. Serialization to
+Protobuf bytes happens downstream, controlled by the connector's `value.converter` setting. The
+SMT itself does not produce Protobuf bytes directly.
+
+### With Confluent Schema Registry (recommended)
+
+```properties
+value.converter=io.confluent.connect.protobuf.ProtobufConverter
+value.converter.schema.registry.url=http://schema-registry:8081
+# Optional: match the Protobuf message name to the Connect schema name
+value.converter.scrub.invalid.names=true
 ```
-raw CDC record
-  → ScyllaExtractNewRecordState   (removes Debezium envelope + Cell wrappers)
-  → YourCustomTransform           (reads flat fields, emits OrderEvent)
-  → Kafka topic
+
+Add the converter to your Kafka Connect plugin path:
+
+```xml
+<!-- pom.xml dependency for packaging -->
+<dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-connect-protobuf-converter</artifactId>
+    <version>7.6.0</version>
+</dependency>
 ```
+
+The converter derives the Protobuf `.proto` schema from the Connect `Schema` automatically and
+registers it in the Schema Registry. The `schema.name` of your `OUTPUT_SCHEMA` becomes the
+Protobuf message name (e.g. `com.example.orders.OrderEvent`), which is also written to the
+`schema-id` header.
+
+### Without Schema Registry
+
+If you manage your `.proto` files and serialization manually, set:
+
+```properties
+value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+```
+
+And perform Protobuf serialization yourself inside `buildPayload` / `apply` using the generated
+Protobuf builder, then return a `ConnectRecord` with a `byte[]` value. This bypasses Connect's
+schema system and is suitable for environments where Schema Registry is not available.
 
 ---
 
@@ -181,6 +299,7 @@ connector configuration.
 ```properties
 transforms=extractState,toOrderEvent
 transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+transforms.extractState.add.fields=op
 transforms.toOrderEvent.type=com.example.orders.MyOrderEventTransform
 transforms.toOrderEvent.target.topic=orders.order-event
 ```
@@ -211,9 +330,12 @@ from `scylla-cdc-lib` to plug in a custom checkpoint backend. See the
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | `ClassNotFoundException` for your SMT | JAR not in plugin directory | Copy JAR to same plugin dir as connector |
-| `NullPointerException` in `buildOutputValue` | Field missing from CDC schema | Use null-safe field accessor; all output fields should be `OPTIONAL` |
+| `event_name` is always `ORDER_UPDATED` | `__op` field missing | Add `add.fields=op` to `ScyllaExtractNewRecordState` config |
+| `NullPointerException` in `buildPayload` | Field missing from CDC schema | Use `getOptionalField`; all output fields should be `OPTIONAL` |
+| Protobuf deserialization error on consumer | Schema mismatch | Ensure `SCHEMA_ID_VALUE` matches the registered `.proto` message name |
 | Records appear with old schema after redeploy | Schema registry cached old schema | Bump the schema version or use `schema.registry.compatibility=NONE` |
-| Tombstones still appearing in output topic | Your SMT returns the record instead of `null` | Return `null` from `apply()` for tombstones |
+| Tombstones still appearing in output topic | SMT returns record instead of `null` | Return `null` from `apply()` for `record.value() == null` |
+| Kafka headers not visible to consumer | Consumer not reading headers | Check consumer `header.deserializer` configuration |
 
 [debezium-format]: https://debezium.io/documentation/reference/stable/connectors/cassandra.html
 [example-smt]: ../src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java

--- a/docs/custom-transformations.md
+++ b/docs/custom-transformations.md
@@ -41,7 +41,8 @@ transforms.reroute.topic.replacement=orders.order-event
 | `ScyllaFlattenColumns` | Flattens nested column structs into a flat key→value record |
 
 Kafka Connect's own transform library (`org.apache.kafka.connect.transforms.*`) adds further
-options: field dropping/renaming, topic routing by regex, timestamp conversion, and more.
+options: field dropping/renaming, topic routing by regex, timestamp conversion, and more. See
+the [Kafka Connect included transformations reference][connect-transforms] for the full list.
 
 ---
 
@@ -217,3 +218,4 @@ from `scylla-cdc-lib` to plug in a custom checkpoint backend. See the
 [debezium-format]: https://debezium.io/documentation/reference/stable/connectors/cassandra.html
 [example-smt]: ../src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
 [state-store-readme]: https://github.com/scylladb/scylla-cdc-java#checkpoint-persistence-cdcstatestore
+[connect-transforms]: https://kafka.apache.org/42/kafka-connect/user-guide/#included-transformations

--- a/docs/custom-transformations.md
+++ b/docs/custom-transformations.md
@@ -1,0 +1,219 @@
+# Custom Output Transformations Guide
+
+This guide explains how to customize the format of records published by the Scylla CDC Source
+Connector. Three levels of customization are covered, from simplest to most powerful.
+
+---
+
+## Overview
+
+The Scylla CDC Source Connector produces [Debezium-style CDC records][debezium-format] by default.
+If you need a different record format — a different topic name, fewer fields, a renamed schema, or
+computed values — you can apply **Single Message Transforms (SMTs)** in the Kafka Connect
+configuration, or write your own SMT class.
+
+---
+
+## Level 1: Config-only — chaining built-in SMTs
+
+Kafka Connect supports chaining multiple transforms via a comma-separated `transforms` list.
+No code changes are required.
+
+**Use case:** Strip the Debezium envelope and flatten Cell wrappers, then rename the topic.
+
+```properties
+# Strip the Debezium "after" envelope and unwrap Scylla legacy Cell structs
+transforms=extractState,reroute
+transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+transforms.extractState.cdc.output.format=legacy
+
+# Reroute all records to a single topic (built-in Kafka Connect SMT)
+transforms.reroute.type=org.apache.kafka.connect.transforms.ReplaceField$Value
+transforms.reroute.topic.regex=.*
+transforms.reroute.topic.replacement=orders.order-event
+```
+
+**Available built-in SMTs provided by this connector:**
+
+| SMT class | What it does |
+|-----------|-------------|
+| `ScyllaExtractNewRecordState` | Unwraps the Debezium envelope; for legacy format also removes Cell struct wrappers |
+| `ScyllaFlattenColumns` | Flattens nested column structs into a flat key→value record |
+
+Kafka Connect's own transform library (`org.apache.kafka.connect.transforms.*`) adds further
+options: field dropping/renaming, topic routing by regex, timestamp conversion, and more.
+
+---
+
+## Level 2: Custom SMT in the connector JAR
+
+Write a Java class implementing `org.apache.kafka.connect.transforms.Transformation<R>`. Place it
+in the same Maven module as the connector. It will be included in the fat JAR automatically — no
+extra build steps or SPI registration are needed.
+
+### Example: `ExampleOrderEventTransform`
+
+The class [`ExampleOrderEventTransform`][example-smt] ships with this connector as a reference
+implementation. It converts a CDC record for an `orders` table into a compact `OrderEvent` message
+on the topic `orders.order-event`.
+
+#### What it does
+
+1. Drops tombstone (DELETE) records — returns `null` to suppress the record downstream.
+2. Reads five application-level fields from the upstream Struct (`order_id`, `customer_id`,
+   `status`, `total_amount`, `updated_at`).
+3. Emits a new record with a clean, flat schema and routes it to the configured target topic.
+4. Silently drops any CDC-internal or extra columns that are not part of the output schema.
+
+#### Step-by-step: adapting the example for your table
+
+1. **Copy and rename** `ExampleOrderEventTransform.java` — e.g. `ShipmentEventTransform.java`.
+
+2. **Update the field list** to match your table's columns:
+   ```java
+   private static final String FIELD_SHIPMENT_ID   = "shipment_id";
+   private static final String FIELD_CARRIER        = "carrier";
+   private static final String FIELD_TRACKING_CODE  = "tracking_code";
+   ```
+
+3. **Define the output schema**:
+   ```java
+   static final Schema OUTPUT_SCHEMA = SchemaBuilder.struct()
+           .name("com.example.shipping.ShipmentEvent")
+           .optional()
+           .field(FIELD_SHIPMENT_ID,  Schema.OPTIONAL_STRING_SCHEMA)
+           .field(FIELD_CARRIER,      Schema.OPTIONAL_STRING_SCHEMA)
+           .field(FIELD_TRACKING_CODE, Schema.OPTIONAL_STRING_SCHEMA)
+           .build();
+   ```
+
+4. **Override `buildOutputValue`** if you need computed fields or type coercions:
+   ```java
+   @Override
+   protected Struct buildOutputValue(Struct input) {
+       Struct output = new Struct(OUTPUT_SCHEMA);
+       output.put(FIELD_SHIPMENT_ID,  getOptionalField(input, FIELD_SHIPMENT_ID, String.class));
+       output.put(FIELD_CARRIER,      getOptionalField(input, FIELD_CARRIER, String.class));
+       // Computed: combine two source fields
+       String tracking = getOptionalField(input, "carrier_prefix", String.class);
+       String code     = getOptionalField(input, "shipment_number", String.class);
+       if (tracking != null && code != null) {
+           output.put(FIELD_TRACKING_CODE, tracking + "-" + code);
+       }
+       return output;
+   }
+   ```
+
+5. **Configure the connector** (runs the new SMT _after_ Cell unwrapping):
+   ```properties
+   transforms=extractState,toShipmentEvent
+   transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+   transforms.toShipmentEvent.type=com.scylladb.cdc.debezium.connector.transforms.ShipmentEventTransform
+   transforms.toShipmentEvent.target.topic=logistics.shipment-event
+   ```
+
+#### Run transform chain order
+
+Transforms run left to right. Always put `ScyllaExtractNewRecordState` (or equivalent) before your
+custom transform so that Cell wrappers are stripped first:
+
+```
+raw CDC record
+  → ScyllaExtractNewRecordState   (removes Debezium envelope + Cell wrappers)
+  → YourCustomTransform           (reads flat fields, emits OrderEvent)
+  → Kafka topic
+```
+
+---
+
+## Level 3: User-supplied SMT JAR
+
+If you cannot (or prefer not to) modify the connector source, you can package your SMT in a
+**separate JAR** and deploy it alongside the connector.
+
+### Option A: Same plugin directory (shared classloader)
+
+Place your JAR in the same directory as the connector plugin JAR. Kafka Connect loads all JARs in
+a plugin directory with the same classloader, so your SMT can reference connector classes
+(e.g. `ScyllaExtractNewRecordState`) if needed.
+
+```
+/kafka/plugins/
+  scylla-cdc-source-connector/
+    scylla-cdc-source-connector-*.jar   ← connector
+    my-order-transforms-1.0.jar         ← your SMT JAR
+```
+
+### Option B: Separate plugin directory (isolated classloader)
+
+Place your JAR in its own plugin directory. It will have an isolated classloader and can only see
+standard Kafka Connect types (`ConnectRecord`, `Schema`, `Struct`, etc.). Useful if you want strict
+isolation or your SMT has conflicting dependencies.
+
+```
+/kafka/plugins/
+  scylla-cdc-source-connector/
+    scylla-cdc-source-connector-*.jar
+  my-order-transforms/
+    my-order-transforms-1.0.jar         ← isolated classloader
+```
+
+### Packaging your SMT
+
+Your `pom.xml` needs only the `kafka-connect-api` dependency (provided scope):
+
+```xml
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>connect-api</artifactId>
+    <version>3.7.0</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+Build with `mvn package` and copy the resulting JAR to the plugin directory. No SPI registration
+(no `META-INF/services/` file) is required — Kafka Connect discovers SMTs by class name from the
+connector configuration.
+
+### Configuration
+
+```properties
+transforms=extractState,toOrderEvent
+transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+transforms.toOrderEvent.type=com.example.orders.MyOrderEventTransform
+transforms.toOrderEvent.target.topic=orders.order-event
+```
+
+---
+
+## External offset management (advanced)
+
+By default, `SourceRecord` objects carry `sourcePartition` / `sourceOffset` maps that Kafka Connect
+persists in its internal offset topic. If you need the connector to checkpoint progress to an
+external store (Redis, a database, etc.) instead, you can use the `commitRecord` and `commit`
+hooks on the `SourceTask`:
+
+- `commitRecord(SourceRecord, RecordMetadata)` — called after each record is successfully produced.
+- `commit()` — called periodically as a bulk flush hint.
+
+Setting `sourcePartition` and `sourceOffset` to `null` disables Connect's internal offset storage
+for those records. Note that this breaks exactly-once but preserves at-least-once delivery.
+
+For standalone Java consumers (not Kafka Connect), use `CDCConsumer.withStateStore(CDCStateStore)`
+from `scylla-cdc-lib` to plug in a custom checkpoint backend. See the
+[scylla-cdc-java README][state-store-readme] for details.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `ClassNotFoundException` for your SMT | JAR not in plugin directory | Copy JAR to same plugin dir as connector |
+| `NullPointerException` in `buildOutputValue` | Field missing from CDC schema | Use null-safe field accessor; all output fields should be `OPTIONAL` |
+| Records appear with old schema after redeploy | Schema registry cached old schema | Bump the schema version or use `schema.registry.compatibility=NONE` |
+| Tombstones still appearing in output topic | Your SMT returns the record instead of `null` | Return `null` from `apply()` for tombstones |
+
+[debezium-format]: https://debezium.io/documentation/reference/stable/connectors/cassandra.html
+[example-smt]: ../src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
+[state-store-readme]: https://github.com/scylladb/scylla-cdc-java#checkpoint-persistence-cdcstatestore

--- a/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
@@ -1,0 +1,166 @@
+package com.scylladb.cdc.debezium.connector.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.Map;
+
+/**
+ * Example Single Message Transform (SMT) that converts a Scylla CDC record for an {@code orders}
+ * table into a compact, application-specific {@code OrderEvent} message.
+ *
+ * <p>This class demonstrates <strong>Level 2 customization</strong>: writing your own SMT that
+ * ships inside the connector plugin JAR. It is intended as a starting point — copy, rename, and
+ * adapt it for your own table schema and output format.
+ *
+ * <h2>What it does</h2>
+ * <ul>
+ *   <li>Reads the <em>after-image</em> fields from a Debezium/Scylla CDC {@code SourceRecord}
+ *       (after {@link ScyllaExtractNewRecordState} or equivalent unwrapping has already run).
+ *   <li>Emits a new record with a simplified, flat schema containing only application-level fields:
+ *       {@code order_id}, {@code customer_id}, {@code status}, {@code total_amount},
+ *       {@code updated_at}.
+ *   <li>Routes the record to the configurable topic (default: {@code orders.order-event}).
+ *   <li>Drops tombstone records (null value) — DELETE events produce no output.
+ * </ul>
+ *
+ * <h2>Expected upstream record schema</h2>
+ * <p>The record value must be a {@link Struct} with at least the fields listed above (all optional).
+ * Run this SMT <em>after</em> {@code ScyllaExtractNewRecordState} so that Cell wrappers have
+ * already been removed.
+ *
+ * <h2>Connector configuration</h2>
+ * <pre>{@code
+ * transforms=extractState,toOrderEvent
+ * transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+ * transforms.toOrderEvent.type=com.scylladb.cdc.debezium.connector.transforms.ExampleOrderEventTransform
+ * transforms.toOrderEvent.target.topic=orders.order-event
+ * }</pre>
+ *
+ * <h2>Adapting this example</h2>
+ * <ol>
+ *   <li>Rename the class and update the field list to match your table.
+ *   <li>Adjust the output {@link Schema} in {@link #OUTPUT_SCHEMA}.
+ *   <li>Override {@link #buildOutputValue} for any field mapping or computation logic.
+ *   <li>Register the class name in the connector config ({@code transforms.*.type}).
+ * </ol>
+ */
+public class ExampleOrderEventTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    /** Configuration key for the output topic. */
+    public static final String TARGET_TOPIC_CONFIG = "target.topic";
+    private static final String TARGET_TOPIC_DEFAULT = "orders.order-event";
+
+    /** Names of the source fields this transform reads from the upstream CDC record. */
+    private static final String FIELD_ORDER_ID = "order_id";
+    private static final String FIELD_CUSTOMER_ID = "customer_id";
+    private static final String FIELD_STATUS = "status";
+    private static final String FIELD_TOTAL_AMOUNT = "total_amount";
+    private static final String FIELD_UPDATED_AT = "updated_at";
+
+    /**
+     * The output schema for the {@code OrderEvent} message.
+     *
+     * <p>All fields are optional so that partial updates (where only some columns changed) do not
+     * cause schema validation failures. Consumers should treat a missing field as "not changed".
+     */
+    static final Schema OUTPUT_SCHEMA = SchemaBuilder.struct()
+            .name("com.example.orders.OrderEvent")
+            .optional()
+            .field(FIELD_ORDER_ID,     Schema.OPTIONAL_STRING_SCHEMA)
+            .field(FIELD_CUSTOMER_ID,  Schema.OPTIONAL_STRING_SCHEMA)
+            .field(FIELD_STATUS,       Schema.OPTIONAL_STRING_SCHEMA)
+            .field(FIELD_TOTAL_AMOUNT, Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field(FIELD_UPDATED_AT,   Schema.OPTIONAL_INT64_SCHEMA)
+            .build();
+
+    private String targetTopic;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        Object topic = configs.get(TARGET_TOPIC_CONFIG);
+        targetTopic = (topic != null) ? topic.toString() : TARGET_TOPIC_DEFAULT;
+    }
+
+    @Override
+    public R apply(R record) {
+        // Drop tombstones (DELETE events)
+        if (record.value() == null) {
+            return null;
+        }
+
+        if (!(record.value() instanceof Struct)) {
+            // Pass through records whose value is not a Struct unchanged
+            return record;
+        }
+
+        Struct inputValue = (Struct) record.value();
+        Struct outputValue = buildOutputValue(inputValue);
+
+        return record.newRecord(
+                targetTopic,
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                OUTPUT_SCHEMA,
+                outputValue,
+                record.timestamp());
+    }
+
+    /**
+     * Maps fields from the CDC after-image {@link Struct} to the output {@code OrderEvent} struct.
+     *
+     * <p>Each field is read with a null-safe helper so that absent or null columns in the CDC
+     * record produce a null value in the output (preserving partial-update semantics).
+     *
+     * @param input the upstream Struct (after Cell unwrapping by a prior SMT)
+     * @return a new Struct conforming to {@link #OUTPUT_SCHEMA}
+     */
+    protected Struct buildOutputValue(Struct input) {
+        Struct output = new Struct(OUTPUT_SCHEMA);
+        output.put(FIELD_ORDER_ID,     getOptionalField(input, FIELD_ORDER_ID,     String.class));
+        output.put(FIELD_CUSTOMER_ID,  getOptionalField(input, FIELD_CUSTOMER_ID,  String.class));
+        output.put(FIELD_STATUS,       getOptionalField(input, FIELD_STATUS,        String.class));
+        output.put(FIELD_TOTAL_AMOUNT, getOptionalField(input, FIELD_TOTAL_AMOUNT, Double.class));
+        output.put(FIELD_UPDATED_AT,   getOptionalField(input, FIELD_UPDATED_AT,   Long.class));
+        return output;
+    }
+
+    /**
+     * Safely reads a field from a {@link Struct}, returning null if the field does not exist in
+     * the schema or its value is null.
+     */
+    @SuppressWarnings("unchecked")
+    private <T> T getOptionalField(Struct struct, String fieldName, Class<T> type) {
+        Field field = struct.schema().field(fieldName);
+        if (field == null) {
+            return null;
+        }
+        Object value = struct.get(field);
+        if (value == null || !type.isInstance(value)) {
+            return null;
+        }
+        return (T) value;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef()
+                .define(TARGET_TOPIC_CONFIG,
+                        ConfigDef.Type.STRING,
+                        TARGET_TOPIC_DEFAULT,
+                        ConfigDef.Importance.MEDIUM,
+                        "The Kafka topic to route transformed records to. "
+                                + "Default: " + TARGET_TOPIC_DEFAULT);
+    }
+
+    @Override
+    public void close() {
+        // No resources to release
+    }
+}

--- a/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransform.java
@@ -9,68 +9,154 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Example Single Message Transform (SMT) that converts a Scylla CDC record for an {@code orders}
- * table into a compact, application-specific {@code OrderEvent} message.
+ * table into a client-ready {@code OrderEvent} Protobuf-envelope message.
  *
- * <p>This class demonstrates <strong>Level 2 customization</strong>: writing your own SMT that
- * ships inside the connector plugin JAR. It is intended as a starting point — copy, rename, and
- * adapt it for your own table schema and output format.
+ * <p>This class demonstrates <strong>Level 2 customization</strong>: a custom SMT that ships
+ * inside the connector plugin JAR. It is intended as a production-realistic starting point —
+ * copy, rename, and adapt it for your own table schema and event conventions.
  *
- * <h2>What it does</h2>
+ * <h2>Output format</h2>
+ * <p>Each record's value is a {@link Struct} with two nested blocks:
+ * <pre>
+ * OrderEvent {
+ *   metadata {
+ *     event_id      String   — randomly generated UUID per message
+ *     event_name    String   — ORDER_CREATED / ORDER_UPDATED / ORDER_DELETED (from CDC op)
+ *     entity_id     String   — copied from order_id (the domain entity key)
+ *     event_ts      Int64    — record timestamp in epoch milliseconds
+ *     state_impact  String   — INSERT / UPDATE / DELETE (from CDC op)
+ *   }
+ *   payload {               — full Order row snapshot
+ *     order_id      String
+ *     customer_id   String
+ *     status        String
+ *     total_amount  Float64
+ *     updated_at    Int64
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>In addition, four <b>Kafka headers</b> are added to every message:
  * <ul>
- *   <li>Reads the <em>after-image</em> fields from a Debezium/Scylla CDC {@code SourceRecord}
- *       (after {@link ScyllaExtractNewRecordState} or equivalent unwrapping has already run).
- *   <li>Emits a new record with a simplified, flat schema containing only application-level fields:
- *       {@code order_id}, {@code customer_id}, {@code status}, {@code total_amount},
- *       {@code updated_at}.
- *   <li>Routes the record to the configurable topic (default: {@code orders.order-event}).
- *   <li>Drops tombstone records (null value) — DELETE events produce no output.
+ *   <li>{@code trace-id} — a UUID generated per message (propagate from upstream in real systems)
+ *   <li>{@code schema-id} — the fully-qualified output schema name
+ *   <li>{@code content-type} — {@code application/x-protobuf} (informational; actual serialization
+ *       is controlled by the connector's {@code value.converter})
+ *   <li>{@code event-source} — configurable string identifying the CDC pipeline (default:
+ *       {@code scylla-cdc})
  * </ul>
  *
- * <h2>Expected upstream record schema</h2>
- * <p>The record value must be a {@link Struct} with at least the fields listed above (all optional).
- * Run this SMT <em>after</em> {@code ScyllaExtractNewRecordState} so that Cell wrappers have
- * already been removed.
- *
  * <h2>Connector configuration</h2>
+ * <p>Run this SMT <em>after</em> {@code ScyllaExtractNewRecordState}. Configure
+ * {@code add.fields=op} on the extraction SMT so that the CDC operation type ({@code __op}) is
+ * available as a value field for this transform to read:
+ *
  * <pre>{@code
  * transforms=extractState,toOrderEvent
+ *
  * transforms.extractState.type=com.scylladb.cdc.debezium.connector.transforms.ScyllaExtractNewRecordState
+ * transforms.extractState.cdc.output.format=advanced
+ * transforms.extractState.add.fields=op
+ * transforms.extractState.delete.tombstone.handling.mode=drop
+ *
  * transforms.toOrderEvent.type=com.scylladb.cdc.debezium.connector.transforms.ExampleOrderEventTransform
  * transforms.toOrderEvent.target.topic=orders.order-event
+ * transforms.toOrderEvent.event.source=my-service
+ *
+ * # Protobuf serialization (requires Confluent Schema Registry)
+ * value.converter=io.confluent.connect.protobuf.ProtobufConverter
+ * value.converter.schema.registry.url=http://schema-registry:8081
  * }</pre>
+ *
+ * <h2>Operation type mapping</h2>
+ * <p>The {@code __op} field (added by {@code add.fields=op}) is mapped as follows:
+ * <table border="1">
+ *   <tr><th>__op</th><th>event_name</th><th>state_impact</th></tr>
+ *   <tr><td>c</td><td>ORDER_CREATED</td><td>INSERT</td></tr>
+ *   <tr><td>u</td><td>ORDER_UPDATED</td><td>UPDATE</td></tr>
+ *   <tr><td>d</td><td>ORDER_DELETED</td><td>DELETE</td></tr>
+ *   <tr><td>(absent)</td><td>ORDER_UPDATED</td><td>UPDATE</td></tr>
+ * </table>
  *
  * <h2>Adapting this example</h2>
  * <ol>
- *   <li>Rename the class and update the field list to match your table.
- *   <li>Adjust the output {@link Schema} in {@link #OUTPUT_SCHEMA}.
- *   <li>Override {@link #buildOutputValue} for any field mapping or computation logic.
- *   <li>Register the class name in the connector config ({@code transforms.*.type}).
+ *   <li>Rename the class and update the {@code event_name} prefix (e.g. {@code SHIPMENT_}).
+ *   <li>Update {@link #PAYLOAD_SCHEMA} and {@link #buildPayload} to match your table columns.
+ *   <li>Change {@link #ENTITY_ID_FIELD} to your table's primary key column name.
+ *   <li>Adjust {@link #SCHEMA_ID_VALUE} to your Protobuf schema's fully-qualified name.
  * </ol>
  */
 public class ExampleOrderEventTransform<R extends ConnectRecord<R>> implements Transformation<R> {
 
-    /** Configuration key for the output topic. */
+    // -------------------------------------------------------------------------
+    // Configuration keys
+    // -------------------------------------------------------------------------
+
+    /** Kafka topic to route transformed records to. */
     public static final String TARGET_TOPIC_CONFIG = "target.topic";
     private static final String TARGET_TOPIC_DEFAULT = "orders.order-event";
 
-    /** Names of the source fields this transform reads from the upstream CDC record. */
-    private static final String FIELD_ORDER_ID = "order_id";
-    private static final String FIELD_CUSTOMER_ID = "customer_id";
-    private static final String FIELD_STATUS = "status";
-    private static final String FIELD_TOTAL_AMOUNT = "total_amount";
-    private static final String FIELD_UPDATED_AT = "updated_at";
+    /** Value of the {@code event-source} Kafka header. */
+    public static final String EVENT_SOURCE_CONFIG = "event.source";
+    private static final String EVENT_SOURCE_DEFAULT = "scylla-cdc";
 
-    /**
-     * The output schema for the {@code OrderEvent} message.
-     *
-     * <p>All fields are optional so that partial updates (where only some columns changed) do not
-     * cause schema validation failures. Consumers should treat a missing field as "not changed".
-     */
-    static final Schema OUTPUT_SCHEMA = SchemaBuilder.struct()
-            .name("com.example.orders.OrderEvent")
+    // -------------------------------------------------------------------------
+    // CDC op codes (produced by ScyllaExtractNewRecordState with add.fields=op)
+    // -------------------------------------------------------------------------
+
+    private static final String OP_CREATE = "c";
+    private static final String OP_UPDATE = "u";
+    private static final String OP_DELETE = "d";
+
+    // -------------------------------------------------------------------------
+    // Domain field names (payload / source record)
+    // -------------------------------------------------------------------------
+
+    /** Name of the field to copy into metadata.entity_id. Change to your PK column. */
+    private static final String ENTITY_ID_FIELD  = "order_id";
+
+    private static final String FIELD_ORDER_ID     = "order_id";
+    private static final String FIELD_CUSTOMER_ID  = "customer_id";
+    private static final String FIELD_STATUS       = "status";
+    private static final String FIELD_TOTAL_AMOUNT = "total_amount";
+    private static final String FIELD_UPDATED_AT   = "updated_at";
+
+    /** The CDC operation type field added by {@code add.fields=op}. */
+    private static final String FIELD_OP = "__op";
+
+    // -------------------------------------------------------------------------
+    // Kafka header names
+    // -------------------------------------------------------------------------
+
+    public static final String HEADER_TRACE_ID     = "trace-id";
+    public static final String HEADER_SCHEMA_ID    = "schema-id";
+    public static final String HEADER_CONTENT_TYPE = "content-type";
+    public static final String HEADER_EVENT_SOURCE = "event-source";
+
+    private static final String CONTENT_TYPE_VALUE  = "application/x-protobuf";
+    private static final String SCHEMA_ID_VALUE     = "com.example.orders.OrderEvent";
+
+    // -------------------------------------------------------------------------
+    // Output schemas
+    // -------------------------------------------------------------------------
+
+    /** Metadata block schema. */
+    static final Schema METADATA_SCHEMA = SchemaBuilder.struct()
+            .name("com.example.orders.OrderEvent.Metadata")
+            .field("event_id",     Schema.STRING_SCHEMA)
+            .field("event_name",   Schema.STRING_SCHEMA)
+            .field("entity_id",    Schema.OPTIONAL_STRING_SCHEMA)
+            .field("event_ts",     Schema.OPTIONAL_INT64_SCHEMA)
+            .field("state_impact", Schema.STRING_SCHEMA)
+            .build();
+
+    /** Payload block schema — full Order row snapshot. */
+    static final Schema PAYLOAD_SCHEMA = SchemaBuilder.struct()
+            .name("com.example.orders.OrderEvent.Payload")
             .optional()
             .field(FIELD_ORDER_ID,     Schema.OPTIONAL_STRING_SCHEMA)
             .field(FIELD_CUSTOMER_ID,  Schema.OPTIONAL_STRING_SCHEMA)
@@ -79,73 +165,68 @@ public class ExampleOrderEventTransform<R extends ConnectRecord<R>> implements T
             .field(FIELD_UPDATED_AT,   Schema.OPTIONAL_INT64_SCHEMA)
             .build();
 
+    /** Top-level OrderEvent envelope schema. */
+    static final Schema OUTPUT_SCHEMA = SchemaBuilder.struct()
+            .name(SCHEMA_ID_VALUE)
+            .field("metadata", METADATA_SCHEMA)
+            .field("payload",  PAYLOAD_SCHEMA)
+            .build();
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
     private String targetTopic;
+    private String eventSource;
+
+    // -------------------------------------------------------------------------
+    // Transformation lifecycle
+    // -------------------------------------------------------------------------
 
     @Override
     public void configure(Map<String, ?> configs) {
         Object topic = configs.get(TARGET_TOPIC_CONFIG);
         targetTopic = (topic != null) ? topic.toString() : TARGET_TOPIC_DEFAULT;
+
+        Object src = configs.get(EVENT_SOURCE_CONFIG);
+        eventSource = (src != null) ? src.toString() : EVENT_SOURCE_DEFAULT;
     }
 
     @Override
     public R apply(R record) {
-        // Drop tombstones (DELETE events)
+        // Drop tombstones (DELETE events represented as null-value records)
         if (record.value() == null) {
             return null;
         }
 
         if (!(record.value() instanceof Struct)) {
-            // Pass through records whose value is not a Struct unchanged
             return record;
         }
 
-        Struct inputValue = (Struct) record.value();
-        Struct outputValue = buildOutputValue(inputValue);
+        Struct input = (Struct) record.value();
+        String op = getOptionalField(input, FIELD_OP, String.class);
 
-        return record.newRecord(
+        Struct metadata = buildMetadata(input, op, record.timestamp());
+        Struct payload  = buildPayload(input);
+
+        Struct output = new Struct(OUTPUT_SCHEMA)
+                .put("metadata", metadata)
+                .put("payload",  payload);
+
+        // Build the new record targeting the configured topic
+        R result = record.newRecord(
                 targetTopic,
                 record.kafkaPartition(),
                 record.keySchema(),
                 record.key(),
                 OUTPUT_SCHEMA,
-                outputValue,
+                output,
                 record.timestamp());
-    }
 
-    /**
-     * Maps fields from the CDC after-image {@link Struct} to the output {@code OrderEvent} struct.
-     *
-     * <p>Each field is read with a null-safe helper so that absent or null columns in the CDC
-     * record produce a null value in the output (preserving partial-update semantics).
-     *
-     * @param input the upstream Struct (after Cell unwrapping by a prior SMT)
-     * @return a new Struct conforming to {@link #OUTPUT_SCHEMA}
-     */
-    protected Struct buildOutputValue(Struct input) {
-        Struct output = new Struct(OUTPUT_SCHEMA);
-        output.put(FIELD_ORDER_ID,     getOptionalField(input, FIELD_ORDER_ID,     String.class));
-        output.put(FIELD_CUSTOMER_ID,  getOptionalField(input, FIELD_CUSTOMER_ID,  String.class));
-        output.put(FIELD_STATUS,       getOptionalField(input, FIELD_STATUS,        String.class));
-        output.put(FIELD_TOTAL_AMOUNT, getOptionalField(input, FIELD_TOTAL_AMOUNT, Double.class));
-        output.put(FIELD_UPDATED_AT,   getOptionalField(input, FIELD_UPDATED_AT,   Long.class));
-        return output;
-    }
+        // Add custom Kafka headers
+        addHeaders(result, op);
 
-    /**
-     * Safely reads a field from a {@link Struct}, returning null if the field does not exist in
-     * the schema or its value is null.
-     */
-    @SuppressWarnings("unchecked")
-    private <T> T getOptionalField(Struct struct, String fieldName, Class<T> type) {
-        Field field = struct.schema().field(fieldName);
-        if (field == null) {
-            return null;
-        }
-        Object value = struct.get(field);
-        if (value == null || !type.isInstance(value)) {
-            return null;
-        }
-        return (T) value;
+        return result;
     }
 
     @Override
@@ -155,12 +236,112 @@ public class ExampleOrderEventTransform<R extends ConnectRecord<R>> implements T
                         ConfigDef.Type.STRING,
                         TARGET_TOPIC_DEFAULT,
                         ConfigDef.Importance.MEDIUM,
-                        "The Kafka topic to route transformed records to. "
-                                + "Default: " + TARGET_TOPIC_DEFAULT);
+                        "Kafka topic to route transformed OrderEvent records to. "
+                                + "Default: " + TARGET_TOPIC_DEFAULT)
+                .define(EVENT_SOURCE_CONFIG,
+                        ConfigDef.Type.STRING,
+                        EVENT_SOURCE_DEFAULT,
+                        ConfigDef.Importance.LOW,
+                        "Value written to the 'event-source' Kafka header. "
+                                + "Default: " + EVENT_SOURCE_DEFAULT);
     }
 
     @Override
     public void close() {
         // No resources to release
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds the metadata block from the CDC record and derived operation fields.
+     *
+     * @param input the flattened CDC value Struct (after ScyllaExtractNewRecordState)
+     * @param op    the CDC operation code ({@code c}/{@code u}/{@code d}), or null if absent
+     * @param timestampMs record timestamp in epoch milliseconds, or null
+     */
+    protected Struct buildMetadata(Struct input, String op, Long timestampMs) {
+        return new Struct(METADATA_SCHEMA)
+                .put("event_id",     UUID.randomUUID().toString())
+                .put("event_name",   resolveEventName(op))
+                .put("entity_id",    getOptionalField(input, ENTITY_ID_FIELD, String.class))
+                .put("event_ts",     timestampMs)
+                .put("state_impact", resolveStateImpact(op));
+    }
+
+    /**
+     * Builds the payload block — the full Order row snapshot from the CDC after-image.
+     *
+     * @param input the flattened CDC value Struct
+     */
+    protected Struct buildPayload(Struct input) {
+        return new Struct(PAYLOAD_SCHEMA)
+                .put(FIELD_ORDER_ID,     getOptionalField(input, FIELD_ORDER_ID,     String.class))
+                .put(FIELD_CUSTOMER_ID,  getOptionalField(input, FIELD_CUSTOMER_ID,  String.class))
+                .put(FIELD_STATUS,       getOptionalField(input, FIELD_STATUS,        String.class))
+                .put(FIELD_TOTAL_AMOUNT, getOptionalField(input, FIELD_TOTAL_AMOUNT, Double.class))
+                .put(FIELD_UPDATED_AT,   getOptionalField(input, FIELD_UPDATED_AT,   Long.class));
+    }
+
+    /**
+     * Adds the four standard Kafka headers to the record.
+     *
+     * <p>Headers are added to the record returned by {@link ConnectRecord#newRecord} — the
+     * {@link org.apache.kafka.connect.header.Headers} object is mutable and changes are reflected
+     * in the record passed to the next SMT or to the producer.
+     */
+    protected void addHeaders(R record, String op) {
+        record.headers().addString(HEADER_TRACE_ID,     UUID.randomUUID().toString());
+        record.headers().addString(HEADER_SCHEMA_ID,    SCHEMA_ID_VALUE);
+        record.headers().addString(HEADER_CONTENT_TYPE, CONTENT_TYPE_VALUE);
+        record.headers().addString(HEADER_EVENT_SOURCE, eventSource);
+    }
+
+    /**
+     * Maps a CDC operation code to a domain event name.
+     *
+     * <p>Falls back to {@code ORDER_UPDATED} when {@code __op} is absent (e.g. the upstream SMT
+     * was not configured with {@code add.fields=op}).
+     */
+    protected String resolveEventName(String op) {
+        if (op == null) return "ORDER_UPDATED";
+        switch (op) {
+            case OP_CREATE: return "ORDER_CREATED";
+            case OP_DELETE: return "ORDER_DELETED";
+            default:        return "ORDER_UPDATED";
+        }
+    }
+
+    /**
+     * Maps a CDC operation code to a state impact label.
+     *
+     * <p>Falls back to {@code UPDATE} when {@code __op} is absent.
+     */
+    protected String resolveStateImpact(String op) {
+        if (op == null) return "UPDATE";
+        switch (op) {
+            case OP_CREATE: return "INSERT";
+            case OP_DELETE: return "DELETE";
+            default:        return "UPDATE";
+        }
+    }
+
+    /**
+     * Safely reads a typed field from a {@link Struct}, returning null if the field does not exist
+     * in the schema or its value is of an unexpected type.
+     */
+    @SuppressWarnings("unchecked")
+    protected <T> T getOptionalField(Struct struct, String fieldName, Class<T> type) {
+        Field field = struct.schema().field(fieldName);
+        if (field == null) {
+            return null;
+        }
+        Object value = struct.get(field);
+        if (value == null || !type.isInstance(value)) {
+            return null;
+        }
+        return (T) value;
     }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransformTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransformTest.java
@@ -3,18 +3,21 @@ package com.scylladb.cdc.debezium.connector.transforms;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ExampleOrderEventTransformTest {
 
+    /** Input schema produced by ScyllaExtractNewRecordState with add.fields=op. */
     private static final Schema INPUT_SCHEMA = SchemaBuilder.struct()
             .optional()
             .field("order_id",     Schema.OPTIONAL_STRING_SCHEMA)
@@ -22,7 +25,8 @@ class ExampleOrderEventTransformTest {
             .field("status",       Schema.OPTIONAL_STRING_SCHEMA)
             .field("total_amount", Schema.OPTIONAL_FLOAT64_SCHEMA)
             .field("updated_at",   Schema.OPTIONAL_INT64_SCHEMA)
-            .field("internal_col", Schema.OPTIONAL_STRING_SCHEMA) // extra column — should be dropped
+            .field("__op",         Schema.OPTIONAL_STRING_SCHEMA)
+            .field("internal_col", Schema.OPTIONAL_STRING_SCHEMA)
             .build();
 
     private ExampleOrderEventTransform<SourceRecord> transform;
@@ -39,6 +43,10 @@ class ExampleOrderEventTransformTest {
     }
 
     private SourceRecord makeRecord(Struct value) {
+        return makeRecord(value, System.currentTimeMillis());
+    }
+
+    private SourceRecord makeRecord(Struct value, long timestamp) {
         return new SourceRecord(
                 Map.of("partition", "0"),
                 Map.of("offset", "0"),
@@ -48,91 +56,250 @@ class ExampleOrderEventTransformTest {
                 "order-123",
                 value == null ? null : value.schema(),
                 value,
-                System.currentTimeMillis());
+                timestamp);
     }
+
+    private Struct makeInput(String op) {
+        return new Struct(INPUT_SCHEMA)
+                .put("order_id",     "ord-1")
+                .put("customer_id",  "cust-42")
+                .put("status",       "CONFIRMED")
+                .put("total_amount", 99.95)
+                .put("updated_at",   1_700_000_000_000L)
+                .put("__op",         op)
+                .put("internal_col", "ignored");
+    }
+
+    // -------------------------------------------------------------------------
+    // Tombstone handling
+    // -------------------------------------------------------------------------
 
     @Test
     void apply_tombstone_returnsNull() {
-        SourceRecord result = transform.apply(makeRecord(null));
-        assertNull(result);
+        assertNull(transform.apply(makeRecord(null)));
     }
 
+    // -------------------------------------------------------------------------
+    // Topic routing
+    // -------------------------------------------------------------------------
+
     @Test
-    void apply_normalRecord_routesToTargetTopic() {
-        Struct input = new Struct(INPUT_SCHEMA)
-                .put("order_id", "ord-1")
-                .put("customer_id", "cust-42")
-                .put("status", "CONFIRMED")
-                .put("total_amount", 99.95)
-                .put("updated_at", 1_700_000_000_000L)
-                .put("internal_col", "ignored");
-
-        SourceRecord result = transform.apply(makeRecord(input));
-
+    void apply_routesToDefaultTopic() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
         assertNotNull(result);
         assertEquals("orders.order-event", result.topic());
     }
 
     @Test
-    void apply_normalRecord_outputSchemaHasExpectedFields() {
-        Struct input = new Struct(INPUT_SCHEMA)
-                .put("order_id", "ord-1")
-                .put("customer_id", "cust-42")
-                .put("status", "CONFIRMED")
-                .put("total_amount", 99.95)
-                .put("updated_at", 1_700_000_000_000L)
-                .put("internal_col", "ignored");
+    void apply_routesToCustomTopic() {
+        ExampleOrderEventTransform<SourceRecord> custom = new ExampleOrderEventTransform<>();
+        custom.configure(Map.of(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG, "my.topic"));
+        SourceRecord result = custom.apply(makeRecord(makeInput("u")));
+        assertEquals("my.topic", result.topic());
+        custom.close();
+    }
 
-        SourceRecord result = transform.apply(makeRecord(input));
-        Struct outputValue = (Struct) result.value();
+    // -------------------------------------------------------------------------
+    // Output schema structure — envelope with metadata + payload
+    // -------------------------------------------------------------------------
 
-        assertEquals("ord-1",              outputValue.get("order_id"));
-        assertEquals("cust-42",            outputValue.get("customer_id"));
-        assertEquals("CONFIRMED",          outputValue.get("status"));
-        assertEquals(99.95,                outputValue.get("total_amount"));
-        assertEquals(1_700_000_000_000L,   outputValue.get("updated_at"));
-        // internal_col must NOT appear in the output schema
-        assertNull(outputValue.schema().field("internal_col"));
+    @Test
+    void apply_outputHasMetadataAndPayloadFields() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
+        Struct output = (Struct) result.value();
+
+        assertNotNull(output.schema().field("metadata"), "missing metadata field");
+        assertNotNull(output.schema().field("payload"),  "missing payload field");
+        assertNull(output.schema().field("internal_col"), "internal_col must not appear in output");
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata block
+    // -------------------------------------------------------------------------
+
+    @Test
+    void metadata_create_hasCorrectEventNameAndStateImpact() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("c"))).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals("ORDER_CREATED", metadata.get("event_name"));
+        assertEquals("INSERT",        metadata.get("state_impact"));
     }
 
     @Test
-    void apply_partialUpdate_missingFieldsAreNull() {
-        // Only order_id and status are present — other fields absent from the struct
-        Schema partialSchema = SchemaBuilder.struct()
-                .optional()
+    void metadata_update_hasCorrectEventNameAndStateImpact() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("u"))).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals("ORDER_UPDATED", metadata.get("event_name"));
+        assertEquals("UPDATE",        metadata.get("state_impact"));
+    }
+
+    @Test
+    void metadata_delete_hasCorrectEventNameAndStateImpact() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("d"))).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals("ORDER_DELETED", metadata.get("event_name"));
+        assertEquals("DELETE",        metadata.get("state_impact"));
+    }
+
+    @Test
+    void metadata_missingOp_fallsBackToUpdate() {
+        // Input schema without __op — simulates missing add.fields=op config
+        Schema schemaNoOp = SchemaBuilder.struct().optional()
+                .field("order_id", Schema.OPTIONAL_STRING_SCHEMA).build();
+        Struct input = new Struct(schemaNoOp).put("order_id", "ord-2");
+
+        Struct output = (Struct) transform.apply(makeRecord(input)).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals("ORDER_UPDATED", metadata.get("event_name"));
+        assertEquals("UPDATE",        metadata.get("state_impact"));
+    }
+
+    @Test
+    void metadata_eventId_isNonNullUUID() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("c"))).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        String eventId = (String) metadata.get("event_id");
+        assertNotNull(eventId);
+        // Must parse as a UUID without throwing
+        assertDoesNotThrow(() -> java.util.UUID.fromString(eventId));
+    }
+
+    @Test
+    void metadata_entityId_copiedFromOrderId() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("u"))).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals("ord-1", metadata.get("entity_id"));
+    }
+
+    @Test
+    void metadata_eventTs_copiedFromRecordTimestamp() {
+        long ts = 1_700_000_000_000L;
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("c"), ts)).value();
+        Struct metadata = (Struct) output.get("metadata");
+
+        assertEquals(ts, metadata.get("event_ts"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Payload block
+    // -------------------------------------------------------------------------
+
+    @Test
+    void payload_containsFullOrderSnapshot() {
+        Struct output = (Struct) transform.apply(makeRecord(makeInput("u"))).value();
+        Struct payload = (Struct) output.get("payload");
+
+        assertEquals("ord-1",              payload.get("order_id"));
+        assertEquals("cust-42",            payload.get("customer_id"));
+        assertEquals("CONFIRMED",          payload.get("status"));
+        assertEquals(99.95,                payload.get("total_amount"));
+        assertEquals(1_700_000_000_000L,   payload.get("updated_at"));
+    }
+
+    @Test
+    void payload_partialUpdate_missingFieldsAreNull() {
+        Schema partialSchema = SchemaBuilder.struct().optional()
                 .field("order_id", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("status",   Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
         Struct input = new Struct(partialSchema)
-                .put("order_id", "ord-2")
+                .put("order_id", "ord-3")
                 .put("status",   "SHIPPED");
 
-        SourceRecord result = transform.apply(makeRecord(input));
-        Struct outputValue = (Struct) result.value();
+        Struct output = (Struct) transform.apply(makeRecord(input)).value();
+        Struct payload = (Struct) output.get("payload");
 
-        assertEquals("ord-2",   outputValue.get("order_id"));
-        assertEquals("SHIPPED", outputValue.get("status"));
-        assertNull(outputValue.get("customer_id"));
-        assertNull(outputValue.get("total_amount"));
-        assertNull(outputValue.get("updated_at"));
+        assertEquals("ord-3",   payload.get("order_id"));
+        assertEquals("SHIPPED", payload.get("status"));
+        assertNull(payload.get("customer_id"));
+        assertNull(payload.get("total_amount"));
+        assertNull(payload.get("updated_at"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Kafka headers
+    // -------------------------------------------------------------------------
+
+    @Test
+    void headers_allFourHeadersPresent() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
+        Map<String, String> headers = headersAsMap(result);
+
+        assertTrue(headers.containsKey(ExampleOrderEventTransform.HEADER_TRACE_ID),
+                "missing trace-id header");
+        assertTrue(headers.containsKey(ExampleOrderEventTransform.HEADER_SCHEMA_ID),
+                "missing schema-id header");
+        assertTrue(headers.containsKey(ExampleOrderEventTransform.HEADER_CONTENT_TYPE),
+                "missing content-type header");
+        assertTrue(headers.containsKey(ExampleOrderEventTransform.HEADER_EVENT_SOURCE),
+                "missing event-source header");
     }
 
     @Test
-    void configure_customTargetTopic_isApplied() {
-        ExampleOrderEventTransform<SourceRecord> customTransform = new ExampleOrderEventTransform<>();
-        customTransform.configure(Map.of(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG, "my.custom-topic"));
-
-        Schema schema = SchemaBuilder.struct().optional()
-                .field("order_id", Schema.OPTIONAL_STRING_SCHEMA).build();
-        Struct input = new Struct(schema).put("order_id", "ord-3");
-
-        SourceRecord result = customTransform.apply(makeRecord(input));
-        assertEquals("my.custom-topic", result.topic());
-        customTransform.close();
+    void headers_contentTypeIsProtobuf() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("u")));
+        assertEquals("application/x-protobuf",
+                headersAsMap(result).get(ExampleOrderEventTransform.HEADER_CONTENT_TYPE));
     }
 
     @Test
-    void config_definesTargetTopicKey() {
-        assertNotNull(transform.config().configKeys().get(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG));
+    void headers_schemaIdMatchesOutputSchemaName() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
+        assertEquals(ExampleOrderEventTransform.OUTPUT_SCHEMA.name(),
+                headersAsMap(result).get(ExampleOrderEventTransform.HEADER_SCHEMA_ID));
+    }
+
+    @Test
+    void headers_traceId_isNonNullUUID() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
+        String traceId = headersAsMap(result).get(ExampleOrderEventTransform.HEADER_TRACE_ID);
+        assertNotNull(traceId);
+        assertDoesNotThrow(() -> java.util.UUID.fromString(traceId));
+    }
+
+    @Test
+    void headers_customEventSource_isApplied() {
+        ExampleOrderEventTransform<SourceRecord> custom = new ExampleOrderEventTransform<>();
+        custom.configure(Map.of(ExampleOrderEventTransform.EVENT_SOURCE_CONFIG, "my-service"));
+        SourceRecord result = custom.apply(makeRecord(makeInput("u")));
+        assertEquals("my-service",
+                headersAsMap(result).get(ExampleOrderEventTransform.HEADER_EVENT_SOURCE));
+        custom.close();
+    }
+
+    @Test
+    void headers_defaultEventSource_isScyllaCdc() {
+        SourceRecord result = transform.apply(makeRecord(makeInput("c")));
+        assertEquals("scylla-cdc",
+                headersAsMap(result).get(ExampleOrderEventTransform.HEADER_EVENT_SOURCE));
+    }
+
+    // -------------------------------------------------------------------------
+    // Config definition
+    // -------------------------------------------------------------------------
+
+    @Test
+    void config_definesBothConfigKeys() {
+        Map<String, ?> keys = transform.config().configKeys();
+        assertNotNull(keys.get(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG));
+        assertNotNull(keys.get(ExampleOrderEventTransform.EVENT_SOURCE_CONFIG));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Map<String, String> headersAsMap(SourceRecord record) {
+        Map<String, String> map = new HashMap<>();
+        for (Header header : record.headers()) {
+            map.put(header.key(), header.value() == null ? null : header.value().toString());
+        }
+        return map;
     }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransformTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/transforms/ExampleOrderEventTransformTest.java
@@ -1,0 +1,138 @@
+package com.scylladb.cdc.debezium.connector.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExampleOrderEventTransformTest {
+
+    private static final Schema INPUT_SCHEMA = SchemaBuilder.struct()
+            .optional()
+            .field("order_id",     Schema.OPTIONAL_STRING_SCHEMA)
+            .field("customer_id",  Schema.OPTIONAL_STRING_SCHEMA)
+            .field("status",       Schema.OPTIONAL_STRING_SCHEMA)
+            .field("total_amount", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("updated_at",   Schema.OPTIONAL_INT64_SCHEMA)
+            .field("internal_col", Schema.OPTIONAL_STRING_SCHEMA) // extra column — should be dropped
+            .build();
+
+    private ExampleOrderEventTransform<SourceRecord> transform;
+
+    @BeforeEach
+    void setUp() {
+        transform = new ExampleOrderEventTransform<>();
+        transform.configure(Collections.emptyMap());
+    }
+
+    @AfterEach
+    void tearDown() {
+        transform.close();
+    }
+
+    private SourceRecord makeRecord(Struct value) {
+        return new SourceRecord(
+                Map.of("partition", "0"),
+                Map.of("offset", "0"),
+                "orders.cdc",
+                null,
+                Schema.OPTIONAL_STRING_SCHEMA,
+                "order-123",
+                value == null ? null : value.schema(),
+                value,
+                System.currentTimeMillis());
+    }
+
+    @Test
+    void apply_tombstone_returnsNull() {
+        SourceRecord result = transform.apply(makeRecord(null));
+        assertNull(result);
+    }
+
+    @Test
+    void apply_normalRecord_routesToTargetTopic() {
+        Struct input = new Struct(INPUT_SCHEMA)
+                .put("order_id", "ord-1")
+                .put("customer_id", "cust-42")
+                .put("status", "CONFIRMED")
+                .put("total_amount", 99.95)
+                .put("updated_at", 1_700_000_000_000L)
+                .put("internal_col", "ignored");
+
+        SourceRecord result = transform.apply(makeRecord(input));
+
+        assertNotNull(result);
+        assertEquals("orders.order-event", result.topic());
+    }
+
+    @Test
+    void apply_normalRecord_outputSchemaHasExpectedFields() {
+        Struct input = new Struct(INPUT_SCHEMA)
+                .put("order_id", "ord-1")
+                .put("customer_id", "cust-42")
+                .put("status", "CONFIRMED")
+                .put("total_amount", 99.95)
+                .put("updated_at", 1_700_000_000_000L)
+                .put("internal_col", "ignored");
+
+        SourceRecord result = transform.apply(makeRecord(input));
+        Struct outputValue = (Struct) result.value();
+
+        assertEquals("ord-1",              outputValue.get("order_id"));
+        assertEquals("cust-42",            outputValue.get("customer_id"));
+        assertEquals("CONFIRMED",          outputValue.get("status"));
+        assertEquals(99.95,                outputValue.get("total_amount"));
+        assertEquals(1_700_000_000_000L,   outputValue.get("updated_at"));
+        // internal_col must NOT appear in the output schema
+        assertNull(outputValue.schema().field("internal_col"));
+    }
+
+    @Test
+    void apply_partialUpdate_missingFieldsAreNull() {
+        // Only order_id and status are present — other fields absent from the struct
+        Schema partialSchema = SchemaBuilder.struct()
+                .optional()
+                .field("order_id", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("status",   Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Struct input = new Struct(partialSchema)
+                .put("order_id", "ord-2")
+                .put("status",   "SHIPPED");
+
+        SourceRecord result = transform.apply(makeRecord(input));
+        Struct outputValue = (Struct) result.value();
+
+        assertEquals("ord-2",   outputValue.get("order_id"));
+        assertEquals("SHIPPED", outputValue.get("status"));
+        assertNull(outputValue.get("customer_id"));
+        assertNull(outputValue.get("total_amount"));
+        assertNull(outputValue.get("updated_at"));
+    }
+
+    @Test
+    void configure_customTargetTopic_isApplied() {
+        ExampleOrderEventTransform<SourceRecord> customTransform = new ExampleOrderEventTransform<>();
+        customTransform.configure(Map.of(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG, "my.custom-topic"));
+
+        Schema schema = SchemaBuilder.struct().optional()
+                .field("order_id", Schema.OPTIONAL_STRING_SCHEMA).build();
+        Struct input = new Struct(schema).put("order_id", "ord-3");
+
+        SourceRecord result = customTransform.apply(makeRecord(input));
+        assertEquals("my.custom-topic", result.topic());
+        customTransform.close();
+    }
+
+    @Test
+    void config_definesTargetTopicKey() {
+        assertNotNull(transform.config().configKeys().get(ExampleOrderEventTransform.TARGET_TOPIC_CONFIG));
+    }
+}


### PR DESCRIPTION
> [!NOTE]  
> This PR is not intended to be merged as of this moment. It serves illustrative purposes only.

## Summary

Adds a production-realistic SMT implementation (`ExampleOrderEventTransform`) and a comprehensive
developer guide covering three levels of output format customization for the Scylla CDC Source
Connector.

The example is modelled on a real client requirement: publish CDC changes from an `orders` table
as Protobuf `OrderEvent` messages on `orders.order-event`, with a metadata block, a full row
snapshot payload, and four custom Kafka headers per message.

## Problem

Users who want to publish CDC changes in a custom format have no documented path forward. The
connector docs explain the built-in SMTs but not how to write or deploy a custom one, how to
derive domain event semantics from the CDC operation type, or how to add Kafka headers.

## Changes

### `ExampleOrderEventTransform`

A fully documented example SMT demonstrating Level 2 customization (ships inside the connector
JAR). Output format:

```
OrderEvent {
  metadata {
    event_id      String   — randomly generated UUID per message
    event_name    String   — ORDER_CREATED / ORDER_UPDATED / ORDER_DELETED (from __op)
    entity_id     String   — copied from order_id
    event_ts      Int64    — record timestamp in epoch milliseconds
    state_impact  String   — INSERT / UPDATE / DELETE (from __op)
  }
  payload {               — full Order row snapshot
    order_id, customer_id, status, total_amount, updated_at
  }
}
```

**Kafka headers** added per message: `trace-id` (UUID), `schema-id`, `content-type`
(`application/x-protobuf`), `event-source` (configurable, default `scylla-cdc`).

**`__op` mapping**: reads the `__op` field added by `ScyllaExtractNewRecordState` with
`add.fields=op`; falls back gracefully to UPDATE semantics when absent.

**Config keys**: `target.topic` (default `orders.order-event`), `event.source` (default
`scylla-cdc`).

**Protected methods** — `buildMetadata`, `buildPayload`, `addHeaders`, `resolveEventName`,
`resolveStateImpact` — are overridable for easy adaptation.

### `docs/custom-transformations.md`

A three-level guide:

| Level | Description |
|-------|-------------|
| 1 | Config-only: chain built-in SMTs (`ScyllaExtractNewRecordState` + [Connect built-ins][connect-transforms]) |
| 2 | Custom SMT in connector JAR: full `ExampleOrderEventTransform` walkthrough including op mapping, headers, Protobuf config, and step-by-step adaptation guide |
| 3 | User-supplied SMT JAR: same plugin dir (shared classloader) vs. separate dir (isolated) |

New sections added:
- **Protobuf serialization** — explains that the SMT produces a `Struct`; serialization to
  Protobuf bytes is handled by `value.converter`. Covers both the Confluent `ProtobufConverter`
  (with Schema Registry) and a manual `ByteArrayConverter` path for environments without one.
- **Kafka headers** — explains mutable `ConnectRecord.headers()` and how the example uses it.
- **Transform chain order** — ASCII diagram showing `ScyllaExtractNewRecordState →
  ExampleOrderEventTransform → value.converter → Kafka topic`.
- **Troubleshooting table** updated with `__op`-missing and Protobuf-specific entries.

### Tests

`ExampleOrderEventTransformTest` — 20 unit tests:
- Tombstone suppression
- Topic routing (default + custom)
- Nested output structure (metadata + payload fields present; internal columns absent)
- `event_name` / `state_impact` for `c`, `u`, `d`, and missing `__op`
- `event_id` is a valid UUID
- `entity_id` copied from `order_id`
- `event_ts` matches record timestamp
- Full payload snapshot
- Partial update — missing fields are null, not exceptions
- All four Kafka headers present
- `content-type` value
- `schema-id` matches output schema name
- `trace-id` is a valid UUID
- Custom and default `event-source`
- Both config keys defined

## Testing

```bash
mvn test -pl . -Dtest=ExampleOrderEventTransformTest
```

[connect-transforms]: https://kafka.apache.org/42/kafka-connect/user-guide/#included-transformations