### PR TITLE
Fix CDC preimage/postimage misalignment with UNLOGGED BATCH

### DIFF
--- a/src/main/java/com/scylladb/cdc/debezium/connector/RowKey.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/RowKey.java
@@ -1,0 +1,81 @@
+package com.scylladb.cdc.debezium.connector;
+
+import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.worker.ChangeSchema;
+import com.scylladb.cdc.model.worker.RawChange;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Composite key identifying a specific row within a CDC task's scope.
+ *
+ * <p>This key combines a {@link TaskId} (which identifies a vnode + table) with the row's primary
+ * key values (partition key + clustering key columns). This ensures that when multiple rows in the
+ * same partition are modified in a single batch, each row gets its own accumulator for
+ * preimage/postimage correlation.
+ *
+ * <p>Without this, all rows sharing the same partition (and therefore the same {@code TaskId})
+ * would collide in the consumer's storage maps, causing preimage misalignment or event loss when
+ * CDC log entries arrive in type-grouped order.
+ *
+ * @see ScyllaChangesConsumer
+ * @see ScyllaChangesConsumerLegacy
+ */
+public final class RowKey {
+
+  private final TaskId taskId;
+  private final List<Object> primaryKeyValues;
+
+  private RowKey(TaskId taskId, List<Object> primaryKeyValues) {
+    this.taskId = Objects.requireNonNull(taskId, "taskId must not be null");
+    this.primaryKeyValues =
+        Collections.unmodifiableList(
+            Objects.requireNonNull(primaryKeyValues, "primaryKeyValues must not be null"));
+  }
+
+  /**
+   * Creates a {@code RowKey} from a task ID and a CDC change event.
+   *
+   * <p>Extracts all partition key and clustering key column values from the change to form a unique
+   * row identifier within the task's scope.
+   *
+   * @param taskId the task ID (identifies vnode + table)
+   * @param change the CDC change event (any operation type: PRE_IMAGE, POST_IMAGE, delta)
+   * @return a RowKey uniquely identifying this row within the task
+   */
+  public static RowKey from(TaskId taskId, RawChange change) {
+    List<Object> pkValues = new ArrayList<>();
+    for (ChangeSchema.ColumnDefinition cdef : change.getSchema().getNonCdcColumnDefinitions()) {
+      ChangeSchema.ColumnType colType = cdef.getBaseTableColumnType();
+      if (colType == ChangeSchema.ColumnType.PARTITION_KEY
+          || colType == ChangeSchema.ColumnType.CLUSTERING_KEY) {
+        pkValues.add(change.getCell(cdef.getColumnName()).getAsObject());
+      }
+    }
+    return new RowKey(taskId, pkValues);
+  }
+
+  public TaskId getTaskId() {
+    return taskId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof RowKey)) return false;
+    RowKey rowKey = (RowKey) o;
+    return taskId.equals(rowKey.taskId) && primaryKeyValues.equals(rowKey.primaryKeyValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(taskId, primaryKeyValues);
+  }
+
+  @Override
+  public String toString() {
+    return "RowKey{taskId=" + taskId + ", pk=" + primaryKeyValues + "}";
+  }
+}

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.debezium.connector;
 
-import com.scylladb.cdc.model.TaskId;
 import com.scylladb.cdc.model.worker.ChangeId;
 import com.scylladb.cdc.model.worker.ChangeSchema;
 import com.scylladb.cdc.model.worker.RawChange;
@@ -44,7 +43,7 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
   private final boolean usePreimages;
   private final boolean usePostimages;
   private final boolean waitPreimageForPartitionDelete;
-  private final Map<TaskId, TaskInfo> taskInfoMap;
+  private final Map<RowKey, TaskInfo> taskInfoMap;
   private final ScyllaConnectorConfig connectorConfig;
   private final long incompleteTaskTimeoutMs;
   private final AtomicLong eventCounter = new AtomicLong(0);
@@ -123,20 +122,20 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
   }
 
   /**
-   * Gets or creates a TaskInfo for the given task ID.
+   * Gets or creates a TaskInfo for the given row key.
    *
-   * @param taskId the task ID
+   * @param rowKey the row key identifying the specific row within the task
    * @return the TaskInfo, never null when taskInfoMap is initialized
    * @throws IllegalStateException if called when taskInfoMap is null (preimages/postimages
    *     disabled)
    */
-  private TaskInfo getOrCreateTaskInfo(TaskId taskId) {
+  private TaskInfo getOrCreateTaskInfo(RowKey rowKey) {
     if (taskInfoMap == null) {
       throw new IllegalStateException(
           "getOrCreateTaskInfo called but taskInfoMap is null. "
               + "This method should only be called when preimages or postimages are enabled.");
     }
-    return taskInfoMap.computeIfAbsent(taskId, k -> createTaskInfo());
+    return taskInfoMap.computeIfAbsent(rowKey, k -> createTaskInfo());
   }
 
   /**
@@ -151,10 +150,10 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
     }
 
     long now = System.currentTimeMillis();
-    Iterator<Map.Entry<TaskId, TaskInfo>> iterator = taskInfoMap.entrySet().iterator();
+    Iterator<Map.Entry<RowKey, TaskInfo>> iterator = taskInfoMap.entrySet().iterator();
 
     while (iterator.hasNext()) {
-      Map.Entry<TaskId, TaskInfo> entry = iterator.next();
+      Map.Entry<RowKey, TaskInfo> entry = iterator.next();
       TaskInfo taskInfo = entry.getValue();
       long age = now - taskInfo.getCreatedAtMillis();
 
@@ -196,24 +195,25 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
       RawChange.OperationType operationType = change.getOperationType();
 
       if (taskInfoMap != null) {
+        RowKey rowKey = RowKey.from(task.id, change);
         TaskInfo taskInfo = null;
         switch (operationType) {
           case PRE_IMAGE:
-            taskInfo = getOrCreateTaskInfo(task.id).setPreImage(change);
+            taskInfo = getOrCreateTaskInfo(rowKey).setPreImage(change);
             break;
           case POST_IMAGE:
-            taskInfo = getOrCreateTaskInfo(task.id).setPostImage(change);
+            taskInfo = getOrCreateTaskInfo(rowKey).setPostImage(change);
             break;
           case ROW_DELETE:
           case ROW_INSERT:
           case ROW_UPDATE:
-            taskInfo = getOrCreateTaskInfo(task.id).setChange(change);
+            taskInfo = getOrCreateTaskInfo(rowKey).setChange(change);
             break;
           case PARTITION_DELETE:
             if (isSinglePartitionDelete(change.getSchema())) {
               // TaskInfo.isComplete() handles the decision on whether to wait for preimage
               // based on the waitPreimageForPartitionDelete flag passed to the constructor
-              taskInfo = getOrCreateTaskInfo(task.id).setChange(change);
+              taskInfo = getOrCreateTaskInfo(rowKey).setChange(change);
             }
             break;
           default:
@@ -223,7 +223,7 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
           advanceStateWithoutDispatching(task, change.getId());
         } else if (taskInfo.isComplete()) {
           // If it is final event that task expects we advance the state and dispatch
-          taskInfoMap.remove(task.id);
+          taskInfoMap.remove(rowKey);
           advanceStateAndDispatch(task, change.getId(), taskInfo);
         }
         // If task is not complete yet (e.g., received PRE_IMAGE but waiting for change),

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumerLegacy.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumerLegacy.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.debezium.connector;
 
-import com.scylladb.cdc.model.TaskId;
 import com.scylladb.cdc.model.worker.ChangeSchema;
 import com.scylladb.cdc.model.worker.RawChange;
 import com.scylladb.cdc.model.worker.Task;
@@ -32,7 +31,7 @@ public class ScyllaChangesConsumerLegacy implements TaskAndRawChangeConsumer {
   private final ScyllaSchemaLegacy schema;
   private final Clock clock;
   private final boolean usePreimages;
-  private final Map<TaskId, RawChange> lastPreImage;
+  private final Map<RowKey, RawChange> lastPreImage;
   private final ScyllaConnectorConfig connectorConfig;
 
   public ScyllaChangesConsumerLegacy(
@@ -58,7 +57,8 @@ public class ScyllaChangesConsumerLegacy implements TaskAndRawChangeConsumer {
   public CompletableFuture<Void> consume(Task task, RawChange change) {
     try {
       if (usePreimages && change.getOperationType() == RawChange.OperationType.PRE_IMAGE) {
-        lastPreImage.put(task.id, change);
+        RowKey rowKey = RowKey.from(task.id, change);
+        lastPreImage.put(rowKey, change);
         if (lastPreImage.size() == PREIMAGE_MAP_SIZE_WARNING_THRESHOLD) {
           logger.warn(
               "Preimage map has grown to {} entries. This may indicate orphaned preimages "
@@ -97,19 +97,20 @@ public class ScyllaChangesConsumerLegacy implements TaskAndRawChangeConsumer {
         return CompletableFuture.completedFuture(null);
       }
 
-      if (usePreimages && lastPreImage.containsKey(task.id)) {
+      if (usePreimages && lastPreImage.containsKey(RowKey.from(task.id, change))) {
+        RowKey rowKey = RowKey.from(task.id, change);
         dispatcher.dispatchDataChangeEvent(
             new ScyllaPartition(offsetContext, taskStateOffsetContext.sourceInfo),
             new CollectionId(task.id.getTable()),
             new ScyllaChangeRecordEmitterLegacy(
                 new ScyllaPartition(offsetContext, taskStateOffsetContext.sourceInfo),
-                lastPreImage.get(task.id),
+                lastPreImage.get(rowKey),
                 change,
                 taskStateOffsetContext,
                 schema,
                 clock,
                 connectorConfig));
-        lastPreImage.remove(task.id);
+        lastPreImage.remove(rowKey);
       } else {
         dispatcher.dispatchDataChangeEvent(
             new ScyllaPartition(offsetContext, taskStateOffsetContext.sourceInfo),
@@ -136,7 +137,7 @@ public class ScyllaChangesConsumerLegacy implements TaskAndRawChangeConsumer {
   }
 
   /** Returns the preimage map for testing purposes. Package-private for test access. */
-  Map<TaskId, RawChange> getPreImageMapForTesting() {
+  Map<RowKey, RawChange> getPreImageMapForTesting() {
     return lastPreImage;
   }
 }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/CdcBatchPreimageMisalignmentIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/CdcBatchPreimageMisalignmentIT.java
@@ -19,13 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 /**
- * Integration test that reproduces CDC preimage misalignment when using UNLOGGED BATCH with
- * multiple UPDATE statements targeting different rows in the same partition.
+ * Regression test for CDC preimage misalignment when using UNLOGGED BATCH with multiple UPDATE
+ * statements targeting different rows in the same partition.
  *
  * <p>Root cause: ScyllaDB generates CDC log entries in type-grouped order for unsplit mutations:
- * [all preimages] -> [all deltas] -> [all postimages]. The connector's preimage/postimage storage
- * is keyed by TaskId (per-vnode), not by row identity. When multiple rows share the same TaskId,
- * later preimage/delta/postimage entries overwrite earlier ones, causing misalignment.
+ * [all preimages] -> [all deltas] -> [all postimages]. Prior to the fix, the connector's
+ * preimage/postimage storage was keyed by TaskId (per-vnode), not by row identity. When multiple
+ * rows shared the same TaskId, later entries would overwrite earlier ones, causing misalignment.
+ *
+ * <p>The fix introduces {@link RowKey} which keys storage by TaskId + primary key column values,
+ * ensuring each row gets its own accumulator.
  *
  * <p>Related issues:
  *
@@ -38,17 +41,16 @@ import org.junit.jupiter.api.TestInfo;
  * Queries the CDC log table directly to confirm that ScyllaDB generates entries in type-grouped
  * order (PRE_IMAGE, PRE_IMAGE, UPDATE, UPDATE, POST_IMAGE, POST_IMAGE) rather than per-row order.
  *
- * <h3>Phase 2: Legacy Format Preimage Misalignment</h3>
+ * <h3>Phase 2: Legacy Format Preimage Correlation</h3>
  *
  * With {@code cdc.output.format=legacy} and {@code experimental.preimages.enabled=true}, verifies
- * that the connector produces 2 UPDATE events where one has the wrong preimage (from a different
- * row) and the other has no preimage at all.
+ * that both UPDATE events have correct preimages matching their respective rows.
  *
- * <h3>Phase 3: Advanced Format Data Loss</h3>
+ * <h3>Phase 3: Advanced Format Event Completeness</h3>
  *
  * With {@code cdc.output.format=advanced}, {@code cdc.include.before=full}, {@code
- * cdc.include.after=full}, verifies that the connector produces only 1 UPDATE event instead of 2
- * (second row's event is lost because its TaskInfo never completes).
+ * cdc.include.after=full}, verifies that both UPDATE events are produced with correctly correlated
+ * before/after data.
  */
 public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
 
@@ -112,7 +114,7 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
       session.execute(
           "CREATE KEYSPACE IF NOT EXISTS "
               + keyspace
-              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+              + " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}");
       session.execute(
           "CREATE TABLE IF NOT EXISTS "
               + fullTableName
@@ -247,17 +249,11 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
   }
 
   /**
-   * Phase 2: Verify that the legacy consumer produces misaligned preimages for UNLOGGED BATCH
-   * operations.
+   * Phase 2: Verify that the legacy consumer correctly correlates preimages with their
+   * corresponding rows in UNLOGGED BATCH operations.
    *
-   * <p>With the legacy format, the consumer stores preimages in {@code Map<TaskId, RawChange>}.
-   * When two preimages arrive before any delta (due to type-grouped ordering), the second
-   * overwrites the first. Result:
-   *
-   * <ul>
-   *   <li>Event 1: dispatched with wrong preimage (from the other row)
-   *   <li>Event 2: dispatched with null preimage (entry was consumed by Event 1)
-   * </ul>
+   * <p>With the fix (RowKey-based storage), each row gets its own preimage entry keyed by PK+CK
+   * values. Both UPDATE events should have correct preimages matching their respective rows.
    */
   @Test
   public void legacyFormatPreimageMisalignmentWithUnloggedBatch(TestInfo testInfo)
@@ -279,7 +275,7 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
       session.execute(
           "CREATE KEYSPACE IF NOT EXISTS "
               + keyspace
-              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+              + " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}");
       session.execute(
           "CREATE TABLE IF NOT EXISTS "
               + fullTableName
@@ -329,81 +325,43 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
       assertEquals("u", event1.getString("op"), "Event 1 should be an update");
       assertEquals("u", event2.getString("op"), "Event 2 should be an update");
 
-      // In legacy format, "before" contains the preimage data (or null)
-      // and "after" contains the delta.
-      // Due to the bug, one event should have the WRONG preimage and one should have NULL.
+      // Both events should have preimages (before != null)
+      assertFalse(event1.isNull("before"), "Event 1 should have a 'before' (preimage)");
+      assertFalse(event2.isNull("before"), "Event 2 should have a 'before' (preimage)");
+      assertFalse(event1.isNull("after"), "Event 1 should have an 'after' (delta)");
+      assertFalse(event2.isNull("after"), "Event 2 should have an 'after' (delta)");
 
-      boolean event1HasBefore = !event1.isNull("before");
-      boolean event2HasBefore = !event2.isNull("before");
+      // Verify each event's preimage matches its own row (not the other row)
+      for (ConsumerRecord<String, String> record : updateRecords) {
+        JSONObject event = new JSONObject(record.value());
+        JSONObject before = event.getJSONObject("before");
+        JSONObject after = event.getJSONObject("after");
 
-      // BUG ASSERTION: Exactly one event should have a preimage, and one should not.
-      // In correct behavior, BOTH events should have preimages.
-      assertNotEquals(
-          event1HasBefore,
-          event2HasBefore,
-          "BUG CONFIRMED: Expected exactly one event with preimage and one without. "
-              + "In correct behavior, both events would have preimages. "
-              + "Event 1 has before="
-              + (event1HasBefore ? "present" : "null")
-              + ", Event 2 has before="
-              + (event2HasBefore ? "present" : "null"));
+        int afterCk = extractLegacyCellIntValue(after, "ck");
+        String beforeV = extractLegacyCellValue(before, "v");
 
-      // Identify which event has the preimage
-      JSONObject eventWithBefore = event1HasBefore ? event1 : event2;
-      JSONObject eventWithoutBefore = event1HasBefore ? event2 : event1;
-
-      // The event WITH a preimage should have a MISALIGNED preimage:
-      // The preimage's 'v' value should NOT match the 'after' row's original value.
-      JSONObject before = eventWithBefore.getJSONObject("before");
-      JSONObject after = eventWithBefore.getJSONObject("after");
-
-      // Extract the clustering key from the 'after' (delta) to identify which row this event is for
-      // In legacy format, after contains Cell structs with {"value": ..., "set": true/false}
-      // but the exact format may vary. Let's extract what we can.
-      String beforeV = extractLegacyCellValue(before, "v");
-      int afterCk = extractLegacyCellIntValue(after, "ck");
-
-      // Determine what the correct preimage 'v' should be for this row
-      String expectedBeforeV = (afterCk == 1) ? "original_A" : "original_B";
-
-      // BUG ASSERTION: The preimage 'v' should NOT match the expected value for this row.
-      // It should be from the OTHER row due to the overwrite.
-      assertNotEquals(
-          expectedBeforeV,
-          beforeV,
-          "BUG CONFIRMED: Preimage 'v' value '"
-              + beforeV
-              + "' does not belong to this row (ck="
-              + afterCk
-              + "). "
-              + "Expected '"
-              + expectedBeforeV
-              + "' but got the other row's preimage due to TaskId collision.");
-
-      // The event WITHOUT a preimage should have had one (it was an UPDATE, not INSERT)
-      assertFalse(
-          eventWithoutBefore.isNull("after"),
-          "Event without preimage should still have an 'after' (delta)");
+        // The preimage 'v' should match the original value for THIS row
+        String expectedBeforeV = (afterCk == 1) ? "original_A" : "original_B";
+        assertEquals(
+            expectedBeforeV,
+            beforeV,
+            "Preimage 'v' for row ck="
+                + afterCk
+                + " should be '"
+                + expectedBeforeV
+                + "' but got '"
+                + beforeV
+                + "'");
+      }
     }
   }
 
   /**
-   * Phase 3: Verify that the advanced consumer loses events for UNLOGGED BATCH operations.
+   * Phase 3: Verify that the advanced consumer correctly produces events for all rows in UNLOGGED
+   * BATCH operations.
    *
-   * <p>With the advanced format using BeforeAfter mode, the consumer stores preimage, change, and
-   * postimage in a single TaskInfo keyed by TaskId. With type-grouped ordering:
-   *
-   * <ol>
-   *   <li>PRE_IMAGE(A) -> stored
-   *   <li>PRE_IMAGE(B) -> overwrites A's preimage
-   *   <li>ROW_UPDATE(A) -> overwrites nothing (change slot empty), stored
-   *   <li>ROW_UPDATE(B) -> overwrites A's change
-   *   <li>POST_IMAGE(A) -> stored, TaskInfo now complete (preImage=B, change=B, postImage=A) ->
-   *       dispatches with ALL WRONG data
-   *   <li>POST_IMAGE(B) -> new TaskInfo, only postImage set -> never completes -> LOST
-   * </ol>
-   *
-   * Result: Only 1 event produced instead of 2. The single event has misaligned data.
+   * <p>With the fix (RowKey-based storage), each row gets its own TaskInfo accumulator. Both rows
+   * should produce UPDATE events with correctly correlated before/after data.
    */
   @Test
   public void advancedFormatDataLossWithUnloggedBatch(TestInfo testInfo) throws Exception {
@@ -424,7 +382,7 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
       session.execute(
           "CREATE KEYSPACE IF NOT EXISTS "
               + keyspace
-              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+              + " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}");
       // Note: use 'preimage': true (not 'full') because the connector's advanced format
       // validation only accepts boolean true, not the string 'full'.
       session.execute(
@@ -466,8 +424,7 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
               + " SET v='updated_B' WHERE pk=1 AND ck=2; "
               + "APPLY BATCH");
 
-      // Wait for UPDATE events - we expect only 1 due to the bug (second row lost)
-      // Wait long enough to be confident no second event is coming
+      // Wait for UPDATE events - expect 2 (one per row)
       List<ConsumerRecord<String, String>> updateRecords =
           waitForKafkaRecordsWithExtraWait(consumer, "batch updates", 20_000);
 
@@ -482,40 +439,36 @@ public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
         }
       }
 
-      // BUG ASSERTION: Only 1 UPDATE event received instead of the expected 2.
-      // The second row's event is lost because its TaskInfo (BeforeAfter) never completes:
-      // POST_IMAGE(B) creates a new TaskInfo with only postImage set, but no preImage or change.
+      // Both rows should produce UPDATE events
       assertEquals(
-          1,
+          2,
           updateOnlyRecords.size(),
-          "BUG CONFIRMED: Expected 2 UPDATE events but got "
-              + updateOnlyRecords.size()
-              + ". The second row's event was lost due to TaskId collision in BeforeAfter mode.");
+          "Expected 2 UPDATE events (one per row in the batch), got " + updateOnlyRecords.size());
 
-      // The single event should have misaligned data
-      JSONObject soleEvent = new JSONObject(updateOnlyRecords.get(0).value());
-      assertFalse(soleEvent.isNull("before"), "The sole event should have a 'before' field");
-      assertFalse(soleEvent.isNull("after"), "The sole event should have an 'after' field");
+      // Each event should have correct before and after fields with matching row identity
+      for (ConsumerRecord<String, String> record : updateOnlyRecords) {
+        JSONObject event = new JSONObject(record.value());
+        assertFalse(event.isNull("before"), "UPDATE event should have a 'before' field");
+        assertFalse(event.isNull("after"), "UPDATE event should have an 'after' field");
 
-      // The before, after fields contain data from DIFFERENT rows due to overwrites
-      JSONObject before = soleEvent.getJSONObject("before");
-      JSONObject after = soleEvent.getJSONObject("after");
+        JSONObject before = event.getJSONObject("before");
+        JSONObject after = event.getJSONObject("after");
 
-      // In advanced format, values are stored directly (not in Cell structs)
-      // Extract clustering keys to verify misalignment
-      int beforeCk = before.optInt("ck", -1);
-      int afterCk = after.optInt("ck", -1);
+        // In advanced format with PK placement in payload, both before and after
+        // should have the same clustering key (same row)
+        int beforeCk = before.optInt("ck", -1);
+        int afterCk = after.optInt("ck", -1);
 
-      // If before and after have different clustering keys, the misalignment is confirmed
-      if (beforeCk != -1 && afterCk != -1 && beforeCk != afterCk) {
-        assertNotEquals(
-            beforeCk,
-            afterCk,
-            "BUG CONFIRMED: before.ck="
-                + beforeCk
-                + " != after.ck="
-                + afterCk
-                + ". Preimage from one row is paired with postimage from another.");
+        if (beforeCk != -1 && afterCk != -1) {
+          assertEquals(
+              beforeCk,
+              afterCk,
+              "before.ck and after.ck should match (same row). "
+                  + "Got before.ck="
+                  + beforeCk
+                  + ", after.ck="
+                  + afterCk);
+        }
       }
     }
   }

--- a/src/test/java/com/scylladb/cdc/debezium/connector/CdcBatchPreimageMisalignmentIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/CdcBatchPreimageMisalignmentIT.java
@@ -1,0 +1,673 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Integration test that reproduces CDC preimage misalignment when using UNLOGGED BATCH with
+ * multiple UPDATE statements targeting different rows in the same partition.
+ *
+ * <p>Root cause: ScyllaDB generates CDC log entries in type-grouped order for unsplit mutations:
+ * [all preimages] -> [all deltas] -> [all postimages]. The connector's preimage/postimage storage
+ * is keyed by TaskId (per-vnode), not by row identity. When multiple rows share the same TaskId,
+ * later preimage/delta/postimage entries overwrite earlier ones, causing misalignment.
+ *
+ * <p>Related issues:
+ *
+ * <ul>
+ *   <li>scylladb/scylla-cdc-java#7 - same class of bug in the replicator's PostImageState
+ * </ul>
+ *
+ * <h3>Phase 1: CDC Log Ordering Verification</h3>
+ *
+ * Queries the CDC log table directly to confirm that ScyllaDB generates entries in type-grouped
+ * order (PRE_IMAGE, PRE_IMAGE, UPDATE, UPDATE, POST_IMAGE, POST_IMAGE) rather than per-row order.
+ *
+ * <h3>Phase 2: Legacy Format Preimage Misalignment</h3>
+ *
+ * With {@code cdc.output.format=legacy} and {@code experimental.preimages.enabled=true}, verifies
+ * that the connector produces 2 UPDATE events where one has the wrong preimage (from a different
+ * row) and the other has no preimage at all.
+ *
+ * <h3>Phase 3: Advanced Format Data Loss</h3>
+ *
+ * With {@code cdc.output.format=advanced}, {@code cdc.include.before=full}, {@code
+ * cdc.include.after=full}, verifies that the connector produces only 1 UPDATE event instead of 2
+ * (second row's event is lost because its TaskInfo never completes).
+ */
+public class CdcBatchPreimageMisalignmentIT extends AbstractContainerBaseIT {
+
+  /** CDC operation type byte values from ScyllaDB's CDC log. */
+  private static final int OP_PRE_IMAGE = 0;
+
+  private static final int OP_ROW_UPDATE = 1;
+  private static final int OP_ROW_INSERT = 2;
+  private static final int OP_POST_IMAGE = 9;
+
+  /** Timeout for waiting for CDC log entries to appear. */
+  private static final long CDC_LOG_TIMEOUT_MS = 30_000;
+
+  /** Timeout for waiting for Kafka events. */
+  private static final long KAFKA_TIMEOUT_MS = 65_000;
+
+  private final List<String> registeredConnectors = new ArrayList<>();
+
+  @AfterEach
+  public void cleanUp() {
+    for (String connectorName : registeredConnectors) {
+      try {
+        KafkaConnectUtils.removeConnector(connectorName);
+      } catch (Exception e) {
+        // Ignore cleanup errors
+      }
+    }
+    registeredConnectors.clear();
+  }
+
+  /**
+   * Phase 1: Verify that ScyllaDB generates CDC log entries in type-grouped order for UNLOGGED
+   * BATCH operations.
+   *
+   * <p>Expected CDC log ordering for a 2-row UNLOGGED BATCH with preimage+postimage:
+   *
+   * <pre>
+   * batch_seq_no 0: PRE_IMAGE  (ck=1)
+   * batch_seq_no 1: PRE_IMAGE  (ck=2)
+   * batch_seq_no 2: ROW_UPDATE (ck=1)
+   * batch_seq_no 3: ROW_UPDATE (ck=2)
+   * batch_seq_no 4: POST_IMAGE (ck=1)
+   * batch_seq_no 5: POST_IMAGE (ck=2)
+   * </pre>
+   */
+  @Test
+  public void verifyCdcLogOrderingForUnloggedBatch(TestInfo testInfo) {
+    String keyspace = keyspaceName(testInfo);
+    String table = tableName(testInfo);
+    String fullTableName = keyspace + "." + table;
+    String cdcLogTable = fullTableName + "_scylla_cdc_log";
+
+    try (Cluster cluster =
+            Cluster.builder()
+                .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
+                .withPort(scyllaDBContainer.getMappedPort(9042))
+                .build();
+        Session session = cluster.connect()) {
+
+      // Create keyspace and table with CDC preimage + postimage
+      session.execute(
+          "CREATE KEYSPACE IF NOT EXISTS "
+              + keyspace
+              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+      session.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + fullTableName
+              + " (pk int, ck int, v text, PRIMARY KEY (pk, ck))"
+              + " WITH cdc = {'enabled': true, 'preimage': 'full', 'postimage': true}");
+
+      // Insert initial data for two rows in the same partition
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 1, 'original_A')");
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 2, 'original_B')");
+
+      // Wait for initial inserts to propagate to CDC log
+      waitForCdcLogEntries(session, cdcLogTable, OP_ROW_INSERT, 2);
+
+      // Execute UNLOGGED BATCH updating both rows
+      session.execute(
+          "BEGIN UNLOGGED BATCH "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_A' WHERE pk=1 AND ck=1; "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_B' WHERE pk=1 AND ck=2; "
+              + "APPLY BATCH");
+
+      // Wait for batch entries to appear in CDC log
+      waitForCdcLogEntries(session, cdcLogTable, OP_ROW_UPDATE, 2);
+
+      // Query all CDC log entries for the batch (same cdc$time as the UPDATE entries)
+      // Find the cdc$time for the UPDATE entries
+      List<Row> updateRows =
+          session
+              .execute(
+                  "SELECT \"cdc$time\", \"cdc$batch_seq_no\", \"cdc$operation\", ck, v "
+                      + "FROM "
+                      + cdcLogTable
+                      + " WHERE \"cdc$operation\" = "
+                      + OP_ROW_UPDATE
+                      + " ALLOW FILTERING")
+              .all();
+
+      assertFalse(updateRows.isEmpty(), "Should have UPDATE entries in CDC log");
+
+      // Get the cdc$time from one of the update rows to find all related entries
+      java.util.UUID batchTime = updateRows.get(0).getUUID("cdc$time");
+
+      // Query all entries with the same cdc$time (preimage + delta + postimage)
+      List<Row> allBatchEntries =
+          session
+              .execute(
+                  "SELECT \"cdc$batch_seq_no\", \"cdc$operation\", ck, v "
+                      + "FROM "
+                      + cdcLogTable
+                      + " WHERE \"cdc$time\" = "
+                      + batchTime
+                      + " ALLOW FILTERING")
+              .all();
+
+      // Sort by batch_seq_no
+      allBatchEntries.sort(
+          (a, b) -> Integer.compare(a.getInt("cdc$batch_seq_no"), b.getInt("cdc$batch_seq_no")));
+
+      // We expect 6 entries: 2 preimages + 2 deltas + 2 postimages
+      assertEquals(
+          6,
+          allBatchEntries.size(),
+          "Expected 6 CDC log entries for 2-row batch with preimage+postimage. Got: "
+              + describeCdcEntries(allBatchEntries));
+
+      // Verify type-grouped ordering
+      // batch_seq 0,1: PRE_IMAGE
+      assertEquals(
+          OP_PRE_IMAGE,
+          allBatchEntries.get(0).getByte("cdc$operation"),
+          "batch_seq_no=0 should be PRE_IMAGE");
+      assertEquals(
+          OP_PRE_IMAGE,
+          allBatchEntries.get(1).getByte("cdc$operation"),
+          "batch_seq_no=1 should be PRE_IMAGE");
+
+      // batch_seq 2,3: ROW_UPDATE
+      assertEquals(
+          OP_ROW_UPDATE,
+          allBatchEntries.get(2).getByte("cdc$operation"),
+          "batch_seq_no=2 should be ROW_UPDATE");
+      assertEquals(
+          OP_ROW_UPDATE,
+          allBatchEntries.get(3).getByte("cdc$operation"),
+          "batch_seq_no=3 should be ROW_UPDATE");
+
+      // batch_seq 4,5: POST_IMAGE
+      assertEquals(
+          OP_POST_IMAGE,
+          allBatchEntries.get(4).getByte("cdc$operation"),
+          "batch_seq_no=4 should be POST_IMAGE");
+      assertEquals(
+          OP_POST_IMAGE,
+          allBatchEntries.get(5).getByte("cdc$operation"),
+          "batch_seq_no=5 should be POST_IMAGE");
+
+      // Verify that preimages contain original values
+      // (rows are in clustering key order: ck=1 first, ck=2 second)
+      int preCk0 = allBatchEntries.get(0).getInt("ck");
+      int preCk1 = allBatchEntries.get(1).getInt("ck");
+      assertTrue(
+          (preCk0 == 1 && preCk1 == 2) || (preCk0 == 2 && preCk1 == 1),
+          "Preimages should cover ck=1 and ck=2, got ck=" + preCk0 + " and ck=" + preCk1);
+
+      // Verify preimage values contain original data
+      String preV0 = allBatchEntries.get(0).getString("v");
+      String preV1 = allBatchEntries.get(1).getString("v");
+      assertTrue(
+          ("original_A".equals(preV0) && "original_B".equals(preV1))
+              || ("original_B".equals(preV0) && "original_A".equals(preV1)),
+          "Preimage values should be original_A and original_B, got: " + preV0 + ", " + preV1);
+
+      // KEY ASSERTION: Verify the ordering is type-grouped, NOT per-row.
+      // If it were per-row, we'd see: PRE_IMAGE, UPDATE, POST_IMAGE, PRE_IMAGE, UPDATE, POST_IMAGE
+      // Instead we see: PRE_IMAGE, PRE_IMAGE, UPDATE, UPDATE, POST_IMAGE, POST_IMAGE
+      // This is what causes the connector bug.
+      int[] operations =
+          allBatchEntries.stream().mapToInt(r -> r.getByte("cdc$operation")).toArray();
+      assertArrayEquals(
+          new int[] {
+            OP_PRE_IMAGE, OP_PRE_IMAGE,
+            OP_ROW_UPDATE, OP_ROW_UPDATE,
+            OP_POST_IMAGE, OP_POST_IMAGE
+          },
+          operations,
+          "CDC log entries should be in type-grouped order, not per-row order. Got: "
+              + describeCdcEntries(allBatchEntries));
+    }
+  }
+
+  /**
+   * Phase 2: Verify that the legacy consumer produces misaligned preimages for UNLOGGED BATCH
+   * operations.
+   *
+   * <p>With the legacy format, the consumer stores preimages in {@code Map<TaskId, RawChange>}.
+   * When two preimages arrive before any delta (due to type-grouped ordering), the second
+   * overwrites the first. Result:
+   *
+   * <ul>
+   *   <li>Event 1: dispatched with wrong preimage (from the other row)
+   *   <li>Event 2: dispatched with null preimage (entry was consumed by Event 1)
+   * </ul>
+   */
+  @Test
+  public void legacyFormatPreimageMisalignmentWithUnloggedBatch(TestInfo testInfo)
+      throws Exception {
+    String keyspace = keyspaceName(testInfo);
+    String table = tableName(testInfo);
+    String fullTableName = keyspace + "." + table;
+    String connectorName = connectorName(testInfo);
+
+    try (Cluster cluster =
+            Cluster.builder()
+                .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
+                .withPort(scyllaDBContainer.getMappedPort(9042))
+                .build();
+        Session session = cluster.connect();
+        KafkaConsumer<String, String> consumer = KafkaUtils.createStringConsumer()) {
+
+      // Create keyspace and table
+      session.execute(
+          "CREATE KEYSPACE IF NOT EXISTS "
+              + keyspace
+              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+      session.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + fullTableName
+              + " (pk int, ck int, v text, PRIMARY KEY (pk, ck))"
+              + " WITH cdc = {'enabled': true, 'preimage': 'full', 'postimage': true}");
+
+      // Insert initial data
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 1, 'original_A')");
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 2, 'original_B')");
+
+      // Register connector with legacy format + preimage enabled
+      Properties props = KafkaConnectUtils.createCommonConnectorProperties();
+      props.put("topic.prefix", connectorName);
+      props.put("scylla.table.names", fullTableName);
+      props.put("name", connectorName);
+      props.put("cdc.output.format", "legacy");
+      props.put("experimental.preimages.enabled", "true");
+      KafkaConnectUtils.registerConnector(props, connectorName);
+      registeredConnectors.add(connectorName);
+      consumer.subscribe(List.of(connectorName + "." + fullTableName));
+
+      // Wait for initial INSERT events to confirm connector is running
+      List<ConsumerRecord<String, String>> insertRecords =
+          waitForKafkaRecords(consumer, 2, "initial inserts");
+
+      // Execute UNLOGGED BATCH updating both rows
+      session.execute(
+          "BEGIN UNLOGGED BATCH "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_A' WHERE pk=1 AND ck=1; "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_B' WHERE pk=1 AND ck=2; "
+              + "APPLY BATCH");
+
+      // Wait for UPDATE events
+      List<ConsumerRecord<String, String>> updateRecords =
+          waitForKafkaRecords(consumer, 2, "batch updates");
+      assertEquals(2, updateRecords.size(), "Should receive exactly 2 UPDATE events");
+
+      // Analyze the events
+      JSONObject event1 = new JSONObject(updateRecords.get(0).value());
+      JSONObject event2 = new JSONObject(updateRecords.get(1).value());
+
+      // Both should be update operations
+      assertEquals("u", event1.getString("op"), "Event 1 should be an update");
+      assertEquals("u", event2.getString("op"), "Event 2 should be an update");
+
+      // In legacy format, "before" contains the preimage data (or null)
+      // and "after" contains the delta.
+      // Due to the bug, one event should have the WRONG preimage and one should have NULL.
+
+      boolean event1HasBefore = !event1.isNull("before");
+      boolean event2HasBefore = !event2.isNull("before");
+
+      // BUG ASSERTION: Exactly one event should have a preimage, and one should not.
+      // In correct behavior, BOTH events should have preimages.
+      assertNotEquals(
+          event1HasBefore,
+          event2HasBefore,
+          "BUG CONFIRMED: Expected exactly one event with preimage and one without. "
+              + "In correct behavior, both events would have preimages. "
+              + "Event 1 has before="
+              + (event1HasBefore ? "present" : "null")
+              + ", Event 2 has before="
+              + (event2HasBefore ? "present" : "null"));
+
+      // Identify which event has the preimage
+      JSONObject eventWithBefore = event1HasBefore ? event1 : event2;
+      JSONObject eventWithoutBefore = event1HasBefore ? event2 : event1;
+
+      // The event WITH a preimage should have a MISALIGNED preimage:
+      // The preimage's 'v' value should NOT match the 'after' row's original value.
+      JSONObject before = eventWithBefore.getJSONObject("before");
+      JSONObject after = eventWithBefore.getJSONObject("after");
+
+      // Extract the clustering key from the 'after' (delta) to identify which row this event is for
+      // In legacy format, after contains Cell structs with {"value": ..., "set": true/false}
+      // but the exact format may vary. Let's extract what we can.
+      String beforeV = extractLegacyCellValue(before, "v");
+      int afterCk = extractLegacyCellIntValue(after, "ck");
+
+      // Determine what the correct preimage 'v' should be for this row
+      String expectedBeforeV = (afterCk == 1) ? "original_A" : "original_B";
+
+      // BUG ASSERTION: The preimage 'v' should NOT match the expected value for this row.
+      // It should be from the OTHER row due to the overwrite.
+      assertNotEquals(
+          expectedBeforeV,
+          beforeV,
+          "BUG CONFIRMED: Preimage 'v' value '"
+              + beforeV
+              + "' does not belong to this row (ck="
+              + afterCk
+              + "). "
+              + "Expected '"
+              + expectedBeforeV
+              + "' but got the other row's preimage due to TaskId collision.");
+
+      // The event WITHOUT a preimage should have had one (it was an UPDATE, not INSERT)
+      assertFalse(
+          eventWithoutBefore.isNull("after"),
+          "Event without preimage should still have an 'after' (delta)");
+    }
+  }
+
+  /**
+   * Phase 3: Verify that the advanced consumer loses events for UNLOGGED BATCH operations.
+   *
+   * <p>With the advanced format using BeforeAfter mode, the consumer stores preimage, change, and
+   * postimage in a single TaskInfo keyed by TaskId. With type-grouped ordering:
+   *
+   * <ol>
+   *   <li>PRE_IMAGE(A) -> stored
+   *   <li>PRE_IMAGE(B) -> overwrites A's preimage
+   *   <li>ROW_UPDATE(A) -> overwrites nothing (change slot empty), stored
+   *   <li>ROW_UPDATE(B) -> overwrites A's change
+   *   <li>POST_IMAGE(A) -> stored, TaskInfo now complete (preImage=B, change=B, postImage=A) ->
+   *       dispatches with ALL WRONG data
+   *   <li>POST_IMAGE(B) -> new TaskInfo, only postImage set -> never completes -> LOST
+   * </ol>
+   *
+   * Result: Only 1 event produced instead of 2. The single event has misaligned data.
+   */
+  @Test
+  public void advancedFormatDataLossWithUnloggedBatch(TestInfo testInfo) throws Exception {
+    String keyspace = keyspaceName(testInfo);
+    String table = tableName(testInfo);
+    String fullTableName = keyspace + "." + table;
+    String connectorName = connectorName(testInfo);
+
+    try (Cluster cluster =
+            Cluster.builder()
+                .addContactPoint(scyllaDBContainer.getContactPoint().getHostName())
+                .withPort(scyllaDBContainer.getMappedPort(9042))
+                .build();
+        Session session = cluster.connect();
+        KafkaConsumer<String, String> consumer = KafkaUtils.createStringConsumer()) {
+
+      // Create keyspace and table
+      session.execute(
+          "CREATE KEYSPACE IF NOT EXISTS "
+              + keyspace
+              + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+      // Note: use 'preimage': true (not 'full') because the connector's advanced format
+      // validation only accepts boolean true, not the string 'full'.
+      session.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + fullTableName
+              + " (pk int, ck int, v text, PRIMARY KEY (pk, ck))"
+              + " WITH cdc = {'enabled': true, 'preimage': true, 'postimage': true}");
+
+      // Insert initial data
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 1, 'original_A')");
+      session.execute("INSERT INTO " + fullTableName + " (pk, ck, v) VALUES (1, 2, 'original_B')");
+
+      // Register connector with advanced format + before/after=full
+      Properties props = KafkaConnectUtils.createCommonConnectorProperties();
+      props.put("topic.prefix", connectorName);
+      props.put("scylla.table.names", fullTableName);
+      props.put("name", connectorName);
+      props.put("cdc.output.format", "advanced");
+      props.put("cdc.include.before", "full");
+      props.put("cdc.include.after", "full");
+      props.put("cdc.include.primary-key.placement", "kafka-key,payload-after,payload-before");
+      KafkaConnectUtils.registerConnector(props, connectorName);
+      registeredConnectors.add(connectorName);
+      consumer.subscribe(List.of(connectorName + "." + fullTableName));
+
+      // Wait for initial INSERT events (2 inserts expected)
+      // Advanced format INSERTs with after=full need postimage, so they should produce 2 events
+      List<ConsumerRecord<String, String>> insertRecords =
+          waitForKafkaRecords(consumer, 2, "initial inserts");
+
+      // Execute UNLOGGED BATCH updating both rows
+      session.execute(
+          "BEGIN UNLOGGED BATCH "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_A' WHERE pk=1 AND ck=1; "
+              + "UPDATE "
+              + fullTableName
+              + " SET v='updated_B' WHERE pk=1 AND ck=2; "
+              + "APPLY BATCH");
+
+      // Wait for UPDATE events - we expect only 1 due to the bug (second row lost)
+      // Wait long enough to be confident no second event is coming
+      List<ConsumerRecord<String, String>> updateRecords =
+          waitForKafkaRecordsWithExtraWait(consumer, "batch updates", 20_000);
+
+      // Count only UPDATE events (filter out any late INSERT events)
+      List<ConsumerRecord<String, String>> updateOnlyRecords = new ArrayList<>();
+      for (ConsumerRecord<String, String> record : updateRecords) {
+        if (record.value() != null) {
+          JSONObject event = new JSONObject(record.value());
+          if ("u".equals(event.optString("op"))) {
+            updateOnlyRecords.add(record);
+          }
+        }
+      }
+
+      // BUG ASSERTION: Only 1 UPDATE event received instead of the expected 2.
+      // The second row's event is lost because its TaskInfo (BeforeAfter) never completes:
+      // POST_IMAGE(B) creates a new TaskInfo with only postImage set, but no preImage or change.
+      assertEquals(
+          1,
+          updateOnlyRecords.size(),
+          "BUG CONFIRMED: Expected 2 UPDATE events but got "
+              + updateOnlyRecords.size()
+              + ". The second row's event was lost due to TaskId collision in BeforeAfter mode.");
+
+      // The single event should have misaligned data
+      JSONObject soleEvent = new JSONObject(updateOnlyRecords.get(0).value());
+      assertFalse(soleEvent.isNull("before"), "The sole event should have a 'before' field");
+      assertFalse(soleEvent.isNull("after"), "The sole event should have an 'after' field");
+
+      // The before, after fields contain data from DIFFERENT rows due to overwrites
+      JSONObject before = soleEvent.getJSONObject("before");
+      JSONObject after = soleEvent.getJSONObject("after");
+
+      // In advanced format, values are stored directly (not in Cell structs)
+      // Extract clustering keys to verify misalignment
+      int beforeCk = before.optInt("ck", -1);
+      int afterCk = after.optInt("ck", -1);
+
+      // If before and after have different clustering keys, the misalignment is confirmed
+      if (beforeCk != -1 && afterCk != -1 && beforeCk != afterCk) {
+        assertNotEquals(
+            beforeCk,
+            afterCk,
+            "BUG CONFIRMED: before.ck="
+                + beforeCk
+                + " != after.ck="
+                + afterCk
+                + ". Preimage from one row is paired with postimage from another.");
+      }
+    }
+  }
+
+  // --- Helper methods ---
+
+  /**
+   * Waits for at least {@code expectedCount} CDC log entries of the given operation type to appear.
+   */
+  private void waitForCdcLogEntries(
+      Session session, String cdcLogTable, int operationType, int expectedCount) {
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < CDC_LOG_TIMEOUT_MS) {
+      List<Row> rows =
+          session
+              .execute(
+                  "SELECT * FROM "
+                      + cdcLogTable
+                      + " WHERE \"cdc$operation\" = "
+                      + operationType
+                      + " ALLOW FILTERING")
+              .all();
+      if (rows.size() >= expectedCount) {
+        return;
+      }
+      Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+    }
+    fail(
+        "Timed out waiting for "
+            + expectedCount
+            + " CDC log entries of operation type "
+            + operationType
+            + " in "
+            + cdcLogTable);
+  }
+
+  /** Waits for at least {@code minCount} Kafka records, with a maximum timeout. */
+  private List<ConsumerRecord<String, String>> waitForKafkaRecords(
+      KafkaConsumer<String, String> consumer, int minCount, String description) {
+    List<ConsumerRecord<String, String>> allRecords = new ArrayList<>();
+    long startTime = System.currentTimeMillis();
+
+    while (System.currentTimeMillis() - startTime < KAFKA_TIMEOUT_MS) {
+      var records = consumer.poll(Duration.ofSeconds(2));
+      records.forEach(allRecords::add);
+      if (allRecords.size() >= minCount) {
+        return allRecords;
+      }
+    }
+
+    // Return whatever we have (test will assert on count)
+    return allRecords;
+  }
+
+  /**
+   * Waits for Kafka records with an extra wait period after the last received record to ensure no
+   * more are coming.
+   */
+  private List<ConsumerRecord<String, String>> waitForKafkaRecordsWithExtraWait(
+      KafkaConsumer<String, String> consumer, String description, long extraWaitMs) {
+    List<ConsumerRecord<String, String>> allRecords = new ArrayList<>();
+    long startTime = System.currentTimeMillis();
+    long lastReceivedTime = 0;
+
+    while (System.currentTimeMillis() - startTime < KAFKA_TIMEOUT_MS) {
+      var records = consumer.poll(Duration.ofSeconds(2));
+      if (!records.isEmpty()) {
+        records.forEach(allRecords::add);
+        lastReceivedTime = System.currentTimeMillis();
+      }
+
+      // If we received at least 1 record and enough time has passed since the last one,
+      // we're confident no more are coming
+      if (!allRecords.isEmpty()
+          && lastReceivedTime > 0
+          && System.currentTimeMillis() - lastReceivedTime > extraWaitMs) {
+        break;
+      }
+    }
+
+    return allRecords;
+  }
+
+  /** Extracts a string value from a legacy format Cell struct ({"value": "...", "set": true}). */
+  private String extractLegacyCellValue(JSONObject row, String columnName) {
+    if (row.isNull(columnName)) {
+      return null;
+    }
+    Object cell = row.opt(columnName);
+    if (cell == null) {
+      return null;
+    }
+    if (cell instanceof JSONObject) {
+      JSONObject cellObj = (JSONObject) cell;
+      return cellObj.has("value") && !cellObj.isNull("value")
+          ? cellObj.optString("value", null)
+          : null;
+    }
+    return cell.toString();
+  }
+
+  /** Extracts an int value from a legacy format Cell struct. */
+  private int extractLegacyCellIntValue(JSONObject row, String columnName) {
+    if (row.isNull(columnName)) {
+      return -1;
+    }
+    Object cell = row.opt(columnName);
+    if (cell == null) {
+      return -1;
+    }
+    if (cell instanceof JSONObject) {
+      JSONObject cellObj = (JSONObject) cell;
+      return cellObj.has("value") && !cellObj.isNull("value") ? cellObj.optInt("value", -1) : -1;
+    }
+    if (cell instanceof Number) {
+      return ((Number) cell).intValue();
+    }
+    return Integer.parseInt(cell.toString());
+  }
+
+  /** Formats CDC log entries for debug messages. */
+  private String describeCdcEntries(List<Row> entries) {
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < entries.size(); i++) {
+      Row row = entries.get(i);
+      if (i > 0) sb.append(", ");
+      sb.append("seq=")
+          .append(row.getInt("cdc$batch_seq_no"))
+          .append(" op=")
+          .append(operationName(row.getByte("cdc$operation")))
+          .append(" ck=")
+          .append(row.getInt("ck"));
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /** Returns a human-readable name for a CDC operation type. */
+  private String operationName(int op) {
+    switch (op) {
+      case 0:
+        return "PRE_IMAGE";
+      case 1:
+        return "ROW_UPDATE";
+      case 2:
+        return "ROW_INSERT";
+      case 3:
+        return "ROW_DELETE";
+      case 9:
+        return "POST_IMAGE";
+      default:
+        return "UNKNOWN(" + op + ")";
+    }
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/LegacyFormatTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/LegacyFormatTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.scylladb.cdc.debezium.connector.ScyllaConnectorConfig.CdcOutputFormat;
-import com.scylladb.cdc.model.TaskId;
 import com.scylladb.cdc.model.worker.RawChange;
 import io.debezium.config.Configuration;
 import io.debezium.schema.DatabaseSchema;
@@ -514,7 +513,7 @@ public class LegacyFormatTest {
       ScyllaChangesConsumerLegacy consumer =
           new ScyllaChangesConsumerLegacy(null, null, schema, null, connectorConfig);
 
-      Map<TaskId, RawChange> lastPreImage = consumer.getPreImageMapForTesting();
+      Map<RowKey, RawChange> lastPreImage = consumer.getPreImageMapForTesting();
 
       assertNull(lastPreImage);
     }
@@ -534,7 +533,7 @@ public class LegacyFormatTest {
       ScyllaChangesConsumerLegacy consumer =
           new ScyllaChangesConsumerLegacy(null, null, schema, null, connectorConfig);
 
-      Map<TaskId, RawChange> lastPreImage = consumer.getPreImageMapForTesting();
+      Map<RowKey, RawChange> lastPreImage = consumer.getPreImageMapForTesting();
 
       assertNotNull(lastPreImage);
       assertEquals("java.util.HashMap", lastPreImage.getClass().getName());

--- a/src/test/java/com/scylladb/cdc/debezium/connector/RowKeyTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/RowKeyTest.java
@@ -1,0 +1,113 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.scylladb.cdc.model.GenerationId;
+import com.scylladb.cdc.model.TableName;
+import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.Timestamp;
+import com.scylladb.cdc.model.VNodeId;
+import com.scylladb.cdc.model.worker.ChangeSchema;
+import com.scylladb.cdc.model.worker.RawChange;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** Unit tests for {@link RowKey}. */
+class RowKeyTest {
+
+  private static final TableName TABLE = new TableName("test_ks", "test_table");
+
+  private static TaskId createTaskId(int vnodeIndex) {
+    GenerationId genId = new GenerationId(new Timestamp(new Date(1000)));
+    VNodeId vnodeId = new VNodeId(vnodeIndex);
+    return new TaskId(genId, vnodeId, TABLE);
+  }
+
+  private static RawChange mockChange(int pk, int ck) {
+    RawChange change = Mockito.mock(RawChange.class);
+
+    ChangeSchema schema = Mockito.mock(ChangeSchema.class);
+    ChangeSchema.ColumnDefinition pkCol = Mockito.mock(ChangeSchema.ColumnDefinition.class);
+    ChangeSchema.ColumnDefinition ckCol = Mockito.mock(ChangeSchema.ColumnDefinition.class);
+
+    Mockito.when(pkCol.getColumnName()).thenReturn("pk");
+    Mockito.when(pkCol.getBaseTableColumnType()).thenReturn(ChangeSchema.ColumnType.PARTITION_KEY);
+    Mockito.when(ckCol.getColumnName()).thenReturn("ck");
+    Mockito.when(ckCol.getBaseTableColumnType()).thenReturn(ChangeSchema.ColumnType.CLUSTERING_KEY);
+
+    Mockito.when(schema.getNonCdcColumnDefinitions()).thenReturn(List.of(pkCol, ckCol));
+    Mockito.when(change.getSchema()).thenReturn(schema);
+
+    com.scylladb.cdc.model.worker.cql.Cell pkCell =
+        Mockito.mock(com.scylladb.cdc.model.worker.cql.Cell.class);
+    com.scylladb.cdc.model.worker.cql.Cell ckCell =
+        Mockito.mock(com.scylladb.cdc.model.worker.cql.Cell.class);
+    Mockito.when(pkCell.getAsObject()).thenReturn(pk);
+    Mockito.when(ckCell.getAsObject()).thenReturn(ck);
+
+    Mockito.when(change.getCell("pk")).thenReturn(pkCell);
+    Mockito.when(change.getCell("ck")).thenReturn(ckCell);
+
+    return change;
+  }
+
+  @Test
+  void sameTaskIdAndSamePkCk_areEqual() {
+    TaskId taskId = createTaskId(1);
+    RawChange change1 = mockChange(1, 10);
+    RawChange change2 = mockChange(1, 10);
+
+    RowKey key1 = RowKey.from(taskId, change1);
+    RowKey key2 = RowKey.from(taskId, change2);
+
+    assertEquals(key1, key2);
+    assertEquals(key1.hashCode(), key2.hashCode());
+  }
+
+  @Test
+  void sameTaskIdButDifferentCk_areNotEqual() {
+    TaskId taskId = createTaskId(1);
+    RawChange changeA = mockChange(1, 1);
+    RawChange changeB = mockChange(1, 2);
+
+    RowKey keyA = RowKey.from(taskId, changeA);
+    RowKey keyB = RowKey.from(taskId, changeB);
+
+    assertNotEquals(keyA, keyB);
+  }
+
+  @Test
+  void differentTaskIdButSamePkCk_areNotEqual() {
+    TaskId taskId1 = createTaskId(1);
+    TaskId taskId2 = createTaskId(2);
+    RawChange change = mockChange(1, 10);
+
+    RowKey key1 = RowKey.from(taskId1, change);
+    RowKey key2 = RowKey.from(taskId2, change);
+
+    assertNotEquals(key1, key2);
+  }
+
+  @Test
+  void canBeUsedAsMapKey() {
+    TaskId taskId = createTaskId(1);
+    RawChange changeA = mockChange(1, 1);
+    RawChange changeB = mockChange(1, 2);
+
+    RowKey keyA = RowKey.from(taskId, changeA);
+    RowKey keyB = RowKey.from(taskId, changeB);
+    // Same row as A
+    RowKey keyA2 = RowKey.from(taskId, mockChange(1, 1));
+
+    java.util.Map<RowKey, String> map = new java.util.HashMap<>();
+    map.put(keyA, "A");
+    map.put(keyB, "B");
+
+    assertEquals("A", map.get(keyA2));
+    assertEquals("B", map.get(keyB));
+    assertEquals(2, map.size());
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumerTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumerTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.scylladb.cdc.debezium.connector.ScyllaConnectorConfig.CdcIncludeMode;
-import com.scylladb.cdc.model.TaskId;
 import io.debezium.config.Configuration;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -36,10 +35,10 @@ public class ScyllaChangesConsumerTest {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<TaskId, TaskInfo> getTaskInfoMap(ScyllaChangesConsumer consumer) throws Exception {
+  private Map<RowKey, TaskInfo> getTaskInfoMap(ScyllaChangesConsumer consumer) throws Exception {
     Field field = ScyllaChangesConsumer.class.getDeclaredField("taskInfoMap");
     field.setAccessible(true);
-    return (Map<TaskId, TaskInfo>) field.get(consumer);
+    return (Map<RowKey, TaskInfo>) field.get(consumer);
   }
 
   @Test
@@ -48,7 +47,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }
@@ -59,7 +58,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }
@@ -70,7 +69,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }
@@ -81,7 +80,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNull(taskInfoMap);
   }
 
@@ -93,7 +92,7 @@ public class ScyllaChangesConsumerTest {
 
     // Access the private method via reflection
     Method method =
-        ScyllaChangesConsumer.class.getDeclaredMethod("getOrCreateTaskInfo", TaskId.class);
+        ScyllaChangesConsumer.class.getDeclaredMethod("getOrCreateTaskInfo", RowKey.class);
     method.setAccessible(true);
 
     // Should throw IllegalStateException
@@ -102,7 +101,7 @@ public class ScyllaChangesConsumerTest {
             Exception.class,
             () -> {
               try {
-                method.invoke(consumer, (TaskId) null);
+                method.invoke(consumer, (RowKey) null);
               } catch (java.lang.reflect.InvocationTargetException e) {
                 throw e.getCause();
               }
@@ -139,7 +138,7 @@ public class ScyllaChangesConsumerTest {
     // Should not throw when map is empty
     cleanupMethod.invoke(consumer);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertEquals(0, taskInfoMap.size());
   }
 
@@ -170,7 +169,7 @@ public class ScyllaChangesConsumerTest {
         new ScyllaChangesConsumer(null, null, null, null, config, null, customTimeoutMs);
 
     // Verify the consumer was created successfully
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
   }
 
@@ -180,7 +179,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
 
     // Verify it's a ConcurrentHashMap
@@ -193,7 +192,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }
@@ -204,7 +203,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }
@@ -216,7 +215,7 @@ public class ScyllaChangesConsumerTest {
     ScyllaChangesConsumer consumer =
         new ScyllaChangesConsumer(null, null, null, null, config, null);
 
-    Map<TaskId, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
+    Map<RowKey, TaskInfo> taskInfoMap = getTaskInfoMap(consumer);
     assertNotNull(taskInfoMap);
     assertEquals(0, taskInfoMap.size());
   }


### PR DESCRIPTION
## Summary

Reproduces and (will) fix the CDC preimage/postimage misalignment bug that occurs when `UNLOGGED BATCH` updates multiple rows in the same partition.

## Root Cause

The connector's preimage/postimage storage is keyed by `TaskId` (GenerationId + VNodeId + TableName), which is per-vnode — **not per-row**. All rows in the same partition share the same `TaskId`.

ScyllaDB generates CDC log entries in **type-grouped order** for unsplit mutations:

```
batch_seq_no 0: PRE_IMAGE  (row A)
batch_seq_no 1: PRE_IMAGE  (row B)   ← overwrites A's preimage
batch_seq_no 2: ROW_UPDATE (row A)   ← dispatched with B's preimage
batch_seq_no 3: ROW_UPDATE (row B)   ← no preimage left
batch_seq_no 4: POST_IMAGE (row A)
batch_seq_no 5: POST_IMAGE (row B)
```

This ordering is produced by `process_changes_without_splitting` in ScyllaDB's `cdc/split.cc`, which groups by operation type before assigning `batch_seq_no`.

### Impact by consumer mode

| Mode | Effect |
|------|--------|
| **Legacy** (`ScyllaChangesConsumerLegacy`) | 2 events produced, but one has wrong preimage (from other row), other has null preimage |
| **Advanced** (`ScyllaChangesConsumer` with BeforeAfter) | Only 1 event produced instead of 2 — second row's event is **lost** entirely |

### Fix approach

Key preimage/postimage storage by row identity (partition key + clustering key) instead of `TaskId`:
- `ScyllaChangesConsumerLegacy.java`: `Map<TaskId, RawChange> lastPreImage` → `Map<RowKey, RawChange>`
- `ScyllaChangesConsumer.java`: `Map<TaskId, TaskInfo> taskInfoMap` → `Map<RowKey, TaskInfo>`

### Related

- [scylladb/scylla-cdc-java#7](https://github.com/scylladb/scylla-cdc-java/issues/7) — same bug class in the replicator's `PostImageState`

## Current state

This PR currently contains only the reproduction tests (`CdcBatchPreimageMisalignmentIT`):

- **Phase 1**: Queries CDC log directly to confirm type-grouped ordering
- **Phase 2**: Legacy format — asserts misaligned preimages (buggy behavior)
- **Phase 3**: Advanced format — asserts event loss (buggy behavior)

All 3 tests pass, confirming the bugs. Assertions will be flipped to check correct behavior once the fix is implemented.