### PR TITLE
ci: fix GitHub Release step condition and idempotency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           git push origin --follow-tags -v
 
       - name: Create GitHub Release
-        if: inputs.dry-run == false
+        if: inputs.dry-run == false && inputs.target-tag == 'master'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make github-release

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ CONNECT_ZIP := $(CHECKOUT_TARGET)/components/packages/scylladb-$(ARTIFACT_ID)-$(
 .PHONY: github-release
 
 github-release:
-	gh release create "$(RELEASE_TAG)" \
-		"$(FAT_JAR)" \
-		"$(CONNECT_ZIP)" \
-		--title "Release $(RELEASE_VERSION)" \
-		--generate-notes
+	if gh release view "$(RELEASE_TAG)" > /dev/null 2>&1; then \
+		gh release upload "$(RELEASE_TAG)" "$(FAT_JAR)" "$(CONNECT_ZIP)" --clobber; \
+	else \
+		gh release create "$(RELEASE_TAG)" \
+			"$(FAT_JAR)" \
+			"$(CONNECT_ZIP)" \
+			--title "Release $(RELEASE_VERSION)" \
+			--generate-notes; \
+	fi


### PR DESCRIPTION
## Summary

Two issues in the `Create GitHub Release` step were identified via Copilot review of the equivalent step added to [kafka-connect-scylladb#178](https://github.com/scylladb/kafka-connect-scylladb/pull/178). The same issues exist here.

---

### Fix 1 — Condition mismatch (`release.yml`)

> `Create GitHub Release` runs for any non-dry-run, but `Push changes to SCM` only runs when `inputs.target-tag == 'master'`. In the `target-tag != 'master'` re-release path the tag may not be pushed/updated on the remote, and `gh release create` can end up creating a release against an existing remote tag pointing at the wrong commit.
>
> — Copilot, [kafka-connect-scylladb#178](https://github.com/scylladb/kafka-connect-scylladb/pull/178#discussion_r3305999469)

**Fix:** align the `if:` condition with the `Push changes to SCM` step:

```yaml
# before
if: inputs.dry-run == false
# after
if: inputs.dry-run == false && inputs.target-tag == 'master'
```

---

### Fix 2 — Non-idempotent on reruns (`Makefile`)

> `gh release create` will fail on reruns when a release for the tag already exists, which makes the workflow non-idempotent (particularly relevant given the workflow has a `target-tag` input for re-running releases).
>
> — Copilot, [kafka-connect-scylladb#178](https://github.com/scylladb/kafka-connect-scylladb/pull/178#discussion_r3305999554)

**Fix:** check for an existing release first; upload/clobber assets if it exists, otherwise create fresh:

```makefile
github-release:
	if gh release view "$(RELEASE_TAG)" > /dev/null 2>&1; then \
		gh release upload "$(RELEASE_TAG)" "$(FAT_JAR)" "$(CONNECT_ZIP)" --clobber; \
	else \
		gh release create "$(RELEASE_TAG)" \
			"$(FAT_JAR)" \
			"$(CONNECT_ZIP)" \
			--title "Release $(RELEASE_VERSION)" \
			--generate-notes; \
	fi
```

---

## Changed files

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Align `Create GitHub Release` condition with `Push changes to SCM` |
| `Makefile` | Make `github-release` target idempotent |