### PR TITLE
fix: override netty to 4.2.15.Final to remediate CVE-2026-44249 and CVE-2026-45416 (Stage 1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,15 +312,18 @@
                 <artifactId>flogger-log4j-backend</artifactId>
                 <version>${flogger.version}</version>
             </dependency>
+            <!-- CVE-2026-44249, CVE-2026-45416: force netty to 4.2.15.Final;
+                 remove once scylladb/scylla-cdc-java bumps netty and a new
+                 scylla-cdc-driver3 release is consumed here (Stage 3). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.15.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.2.9.Final</version>
+                <version>4.2.15.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
## Summary

Closes #276 (Stage 1 of 3)

Confluent Hub security scan flagged connector `2.0.2` for CVE-2026-44249 and CVE-2026-45416 in `io.netty:netty-handler`. This PR applies an **immediate workaround** by bumping the existing `<dependencyManagement>` entries for `netty-common` and `netty-handler` from `4.2.9.Final` to `4.2.15.Final`.

## Vulnerabilities

| CVE | Severity | CVSS | Description |
|---|---|---|---|
| CVE-2026-44249 | HIGH | 8.1 | IPv6 subnet rule bypass via incorrect masking in `IpSubnetFilterRule.compareTo()` |
| CVE-2026-45416 | HIGH | 7.5 | Unbounded 16 MiB memory allocation in `SslClientHelloHandler.decode()` (DoS) |

## What this fixes

This PR fixes **Source B** — the transitive `netty-handler:4.2.9.Final` pulled in via `scylla-driver-core:3.11.5.11`.

**Source A** — the shaded copy of `netty-handler:4.2.10.Final` embedded inside `scylla-cdc-driver3-1.3.11.jar` — **remains vulnerable** until a new `scylla-cdc-java` release is consumed (Stage 3).

## Changes

- `pom.xml`: bump `netty-common` from `4.2.9.Final` to `4.2.15.Final` in `<dependencyManagement>`
- `pom.xml`: bump `netty-handler` from `4.2.9.Final` to `4.2.15.Final` in `<dependencyManagement>`
- `pom.xml`: add comment documenting the CVE override and Stage 3 removal plan

## Verification

```
$ mvn dependency:tree -Dincludes=io.netty
...
\- io.netty:netty-handler:jar:4.2.15.Final:compile
   +- io.netty:netty-common:jar:4.2.15.Final:compile
   +- io.netty:netty-resolver:jar:4.2.15.Final:compile
   +- io.netty:netty-buffer:jar:4.2.15.Final:compile
   +- io.netty:netty-transport:jar:4.2.15.Final:compile
   +- io.netty:netty-transport-native-unix-common:jar:4.2.15.Final:compile
   \- io.netty:netty-codec-base:jar:4.2.15.Final:compile
```

All 7 netty artifacts resolve to `4.2.15.Final`.

## Follow-up

- **Stage 2:** scylladb/scylla-cdc-java — bump netty in `scylla-cdc-driver3` (root fix for shaded jar)
- **Stage 3:** Once a new `scylla-cdc-java` release is cut, bump `scylla.cdc.java.version` here and remove the overrides
