### PR TITLE
Fix sender address in test-email workflow

### DIFF
--- a/.github/workflows/test-email.yml
+++ b/.github/workflows/test-email.yml
@@ -16,7 +16,7 @@ jobs:
           secure: true
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
-          from: publish.code@scylladb.com
+          from: drivers-team-bot@scylladb.com
           to: drivers-team@scylladb.com
           subject: "[TEST] Email automation verification"
           body: |


### PR DESCRIPTION
The sending account was changed mid-implementation from `publish.code@scylladb.com` to `drivers-team-bot@scylladb.com`, but `test-email.yml` was never updated to match.

This aligns the `from:` field with the account whose credentials are stored in the `EMAIL_USERNAME` / `EMAIL_PASSWORD` secrets and used in the release workflow.