### PR TITLE
fix(deps): update Jackson to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,7 @@
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.4</log4j.version>
-        <jackson-databind.version>2.21.1</jackson-databind.version>
-        <jackson-core.version>2.21.1</jackson-core.version>
+        <jackson.version>2.22.1</jackson.version>
         <guava.version>33.5.0-jre</guava.version>
         <jetty.version>12.1.7</jetty.version>
         <commons.version>3.19.0</commons.version>
@@ -239,13 +238,13 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
-            <!-- Override jackson-core pulled transitively from debezium-core to address GHSA-72hv-8253-57qq; version must match jackson-databind -->
+            <!-- Override jackson-core pulled transitively from debezium-core; keep Jackson core modules aligned. -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${jackson-core.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Summary

Supersedes #282.

- Replace the separate `jackson-databind.version` and `jackson-core.version` properties with a single `jackson.version` property.
- Bump connector-managed `jackson-core` and `jackson-databind` from `2.21.1` to `2.22.1`.
- Keep the Debezium transitive override in place so connector-owned Jackson jars resolve past the CVE report's fixed-version requirements, including `CVE-2026-54515` requiring newer than `2.21.4`.

## Scope

This addresses the connector-owned `jackson-databind-2.21.1.jar` rows from #280. It does not close #280 by itself because `scylla-cdc-driver3-1.3.11.jar` still embeds older Jackson/Netty classes; that requires a patched `scylla-cdc-java` release before this connector can consume it.

## Verification

- `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind,com.fasterxml.jackson.core:jackson-core,com.fasterxml.jackson.core:jackson-annotations -Dverbose`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem PATH=$HOME/.sdkman/candidates/java/17.0.17-tem/bin:$PATH mvn -DskipITs clean verify`

Result: 141 unit tests passed; integration tests skipped with `-DskipITs`; fmt check passed.

Built connector package contains:

- `lib/jackson-core-2.22.1.jar`
- `lib/jackson-databind-2.22.1.jar`
- `lib/netty-handler-4.2.15.Final.jar`
