### PR TITLE
feat: configure non-frozen collection empty output

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,18 @@ Maps are represented as arrays of key-value structs:
 
 This representation is used instead of a JSON object to support non-string key types.
 
+### Non-Frozen Empty and Null Collections
+
+Scylla CDC does not distinguish an explicit `NULL` from an explicit empty non-frozen collection when no element-level changes are present. By default, the connector preserves the existing behavior and emits these ambiguous values as `null`.
+
+To emit ambiguous non-frozen collection values as empty arrays instead, set:
+
+```properties
+cdc.non-frozen-collections.empty-representation=empty
+```
+
+The default value is `null`. The `empty` mode emits `[]` for non-frozen lists, sets, and maps. Maps are still represented as arrays of key-value structs, so an empty map is also `[]`.
+
 ### User Defined Types (UDT)
 
 UDTs are represented as structs with fields matching the UDT definition:
@@ -1179,6 +1191,7 @@ The connector supports including the complete row state before and/or after a ch
 | `cdc.include.after`  | `none`  | `none`, `full`, `only-updated` | Specifies whether to include the 'after' state of the row in CDC messages. Requires the Scylla table to have postimage enabled (`WITH cdc = {'postimage': true}`) for `full` or `only-updated` modes. |
 | `cdc.include.primary-key.placement` | `kafka-key,payload-after,payload-before` | Comma-separated list of: `kafka-key`, `payload-after`, `payload-before`, `payload-key`, `kafka-headers` | Specifies where primary key (PK) and clustering key (CK) columns should be included in the output. See [Primary Key Placement](#primary-key-placement) for details. |
 | `cdc.include.primary-key.payload-key-name` | `key` | Any valid field name | Specifies the field name for the primary key object in the message payload when `payload-key` is included in `cdc.include.primary-key.placement`. |
+| `cdc.non-frozen-collections.empty-representation` | `null` | `null`, `empty` | Controls how ambiguous NULL/empty values for non-frozen collection columns are emitted. Use `null` to preserve existing behavior, or `empty` to emit empty arrays. |
 | `cdc.incomplete.task.timeout.ms` | `15000` | Positive integer (milliseconds) | Timeout for incomplete CDC tasks waiting for preimage/postimage events. Tasks that remain incomplete longer than this duration are dropped and logged as errors. |
 
 #### Mode Descriptions

--- a/cp-quickstart/setup-connector.sh
+++ b/cp-quickstart/setup-connector.sh
@@ -61,6 +61,7 @@ CONNECTOR_CONFIG_ONLY=$(cat <<'JSON'
   "topic.prefix": "scylla_cluster",
   "scylla.table.names": "demo_keyspace.users",
   "scylla.consistency.level": "ONE",
+  "cdc.non-frozen-collections.empty-representation": "null",
   "key.converter": "org.apache.kafka.connect.json.JsonConverter",
   "value.converter": "org.apache.kafka.connect.json.JsonConverter",
   "key.converter.schemas.enable": "false",

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangeRecordEmitter.java
@@ -445,8 +445,8 @@ public class ScyllaChangeRecordEmitter
     for (ChangeSchema.ColumnDefinition cdef : image.getSchema().getNonCdcColumnDefinitions()) {
       String columnName = cdef.getColumnName();
       Object value =
-          translateCellToKafka(
-              getCellSafe(image, columnName), collectionSchema.cellSchema(columnName));
+          translateColumnToKafka(
+              cdef, getCellSafe(image, columnName), collectionSchema.cellSchema(columnName));
 
       if (isPrimaryKeyColumn(cdef)) {
         if (includePk) {
@@ -482,8 +482,8 @@ public class ScyllaChangeRecordEmitter
     for (ChangeSchema.ColumnDefinition cdef : image.getSchema().getNonCdcColumnDefinitions()) {
       String columnName = cdef.getColumnName();
       Object value =
-          translateCellToKafka(
-              getCellSafe(image, columnName), collectionSchema.cellSchema(columnName));
+          translateColumnToKafka(
+              cdef, getCellSafe(image, columnName), collectionSchema.cellSchema(columnName));
 
       if (isPrimaryKeyColumn(cdef)) {
         if (includePk) {
@@ -558,16 +558,20 @@ public class ScyllaChangeRecordEmitter
         continue;
       }
       Object value =
-          translateCellToKafka(
-              getCellSafe(postImage, columnName), collectionSchema.cellSchema(columnName));
+          translateColumnToKafka(
+              cdef, getCellSafe(postImage, columnName), collectionSchema.cellSchema(columnName));
       valueStruct.put(columnName, value);
     }
 
     // Fill modified columns from preImage (which has the OLD values)
-    for (String columnName : modifiedColumns) {
+    for (ChangeSchema.ColumnDefinition cdef : preImage.getSchema().getNonCdcColumnDefinitions()) {
+      String columnName = cdef.getColumnName();
+      if (!modifiedColumns.contains(columnName)) {
+        continue;
+      }
       Object value =
-          translateCellToKafka(
-              getCellSafe(preImage, columnName), collectionSchema.cellSchema(columnName));
+          translateColumnToKafka(
+              cdef, getCellSafe(preImage, columnName), collectionSchema.cellSchema(columnName));
       valueStruct.put(columnName, value);
     }
 
@@ -622,6 +626,33 @@ public class ScyllaChangeRecordEmitter
       return null;
     }
     return translateFieldToKafka(cell, cellSchema);
+  }
+
+  private Object translateColumnToKafka(
+      ChangeSchema.ColumnDefinition cdef, Cell cell, Schema cellSchema) {
+    Object value = translateCellToKafka(cell, cellSchema);
+    if (value == null && shouldEmitEmptyNonFrozenCollection(cdef)) {
+      return Collections.emptyList();
+    }
+    return value;
+  }
+
+  private boolean shouldEmitEmptyNonFrozenCollection(ChangeSchema.ColumnDefinition cdef) {
+    return connectorConfig.getNonFrozenCollectionEmptyRepresentation()
+            == ScyllaConnectorConfig.NonFrozenCollectionEmptyRepresentation.EMPTY
+        && isNonFrozenCollectionColumn(cdef);
+  }
+
+  private static boolean isNonFrozenCollectionColumn(ChangeSchema.ColumnDefinition cdef) {
+    ChangeSchema.DataType baseTableType = cdef.getBaseTableDataType();
+    if (baseTableType == null || baseTableType.isFrozen()) {
+      return false;
+    }
+
+    ChangeSchema.CqlType cqlType = baseTableType.getCqlType();
+    return cqlType == ChangeSchema.CqlType.LIST
+        || cqlType == ChangeSchema.CqlType.SET
+        || cqlType == ChangeSchema.CqlType.MAP;
   }
 
   /** Converts a Scylla CDC field value into a Kafka Connect-compatible representation. */

--- a/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -39,6 +39,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
   public static final String CDC_INCLUDE_PK_PAYLOAD_KEY_NAME_KEY =
       "cdc.include.primary-key.payload-key-name";
 
+  /** Configuration key for ambiguous non-frozen collection null/empty representation. */
+  public static final String CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION_KEY =
+      "cdc.non-frozen-collections.empty-representation";
+
   /** Default value for the payload key field name. */
   public static final String CDC_INCLUDE_PK_PAYLOAD_KEY_NAME_DEFAULT = "key";
 
@@ -306,6 +310,21 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
                   + "when 'payload-key' is included in cdc.include.primary-key.placement. "
                   + "Default is 'key'.");
 
+  public static final Field CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION =
+      Field.create(CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION_KEY)
+          .withDisplayName("CDC Non-Frozen Collections Empty Representation")
+          .withEnum(
+              NonFrozenCollectionEmptyRepresentation.class,
+              NonFrozenCollectionEmptyRepresentation.NULL)
+          .withWidth(ConfigDef.Width.MEDIUM)
+          .withImportance(ConfigDef.Importance.LOW)
+          .withDescription(
+              "Controls how ambiguous NULL/empty values for non-frozen collection columns are "
+                  + "emitted. Scylla CDC does not distinguish explicit NULL from an empty "
+                  + "non-frozen collection when no element-level changes are present. Use 'null' "
+                  + "to preserve the existing behavior, or 'empty' to emit an empty array. "
+                  + "Default is 'null'.");
+
   public static final Field CDC_INCOMPLETE_TASK_TIMEOUT_MS =
       Field.create("cdc.incomplete.task.timeout.ms")
           .withDisplayName("Incomplete Task Timeout (ms)")
@@ -540,6 +559,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
               CDC_INCLUDE_AFTER,
               CDC_INCLUDE_PK,
               CDC_INCLUDE_PK_PAYLOAD_KEY_NAME,
+              CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION,
               CDC_INCOMPLETE_TASK_TIMEOUT_MS,
               RETRY_BACKOFF_BASE_MS,
               RETRY_MAX_BACKOFF_MS,
@@ -574,6 +594,7 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
   private final CdcIncludeMode cdcIncludeBefore;
   private final CdcIncludeMode cdcIncludeAfter;
   private final PkLocationConfig pkLocationConfig;
+  private final NonFrozenCollectionEmptyRepresentation nonFrozenCollectionEmptyRepresentation;
 
   /** Pre-computed boolean flags for PK location configuration to avoid repeated EnumSet lookups. */
   public static class PkLocationConfig {
@@ -604,6 +625,9 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
     this.pkLocationConfig =
         new PkLocationConfig(
             CdcIncludePkLocation.parseList(config.getList(ScyllaConnectorConfig.CDC_INCLUDE_PK)));
+    this.nonFrozenCollectionEmptyRepresentation =
+        NonFrozenCollectionEmptyRepresentation.parse(
+            config.getString(CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION));
   }
 
   public static ConfigDef configDef() {
@@ -723,6 +747,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
 
   public String getCdcIncludePkPayloadKeyName() {
     return config.getString(ScyllaConnectorConfig.CDC_INCLUDE_PK_PAYLOAD_KEY_NAME);
+  }
+
+  public NonFrozenCollectionEmptyRepresentation getNonFrozenCollectionEmptyRepresentation() {
+    return nonFrozenCollectionEmptyRepresentation;
   }
 
   public long getIncompleteTaskTimeoutMs() {
@@ -889,6 +917,35 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
         }
       }
       return NONE;
+    }
+  }
+
+  public enum NonFrozenCollectionEmptyRepresentation implements EnumeratedValue {
+    NULL("null"),
+    EMPTY("empty");
+
+    private final String value;
+
+    NonFrozenCollectionEmptyRepresentation(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    public static NonFrozenCollectionEmptyRepresentation parse(String value) {
+      if (value == null) {
+        return NULL;
+      }
+      String normalized = value.trim().toLowerCase(Locale.ROOT);
+      for (NonFrozenCollectionEmptyRepresentation representation : values()) {
+        if (representation.getValue().equals(normalized)) {
+          return representation;
+        }
+      }
+      return NULL;
     }
   }
 

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfigTest.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfigTest.java
@@ -1,0 +1,59 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.scylladb.cdc.debezium.connector.ScyllaConnectorConfig.NonFrozenCollectionEmptyRepresentation;
+import io.debezium.config.Configuration;
+import org.junit.jupiter.api.Test;
+
+public class ScyllaConnectorConfigTest {
+
+  private Configuration.Builder createMinimalConfigBuilder() {
+    return Configuration.create()
+        .with("name", "test-connector")
+        .with("topic.prefix", "test")
+        .with("scylla.cluster.ip.addresses", "127.0.0.1:9042")
+        .with("scylla.table.names", "ks.table");
+  }
+
+  @Test
+  void nonFrozenCollectionEmptyRepresentationDefaultIsNull() {
+    ScyllaConnectorConfig config = new ScyllaConnectorConfig(createMinimalConfigBuilder().build());
+
+    assertEquals(
+        NonFrozenCollectionEmptyRepresentation.NULL,
+        config.getNonFrozenCollectionEmptyRepresentation());
+  }
+
+  @Test
+  void nonFrozenCollectionEmptyRepresentationCanBeSetToEmpty() {
+    ScyllaConnectorConfig config =
+        new ScyllaConnectorConfig(
+            createMinimalConfigBuilder()
+                .with(
+                    ScyllaConnectorConfig.CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION_KEY,
+                    "empty")
+                .build());
+
+    assertEquals(
+        NonFrozenCollectionEmptyRepresentation.EMPTY,
+        config.getNonFrozenCollectionEmptyRepresentation());
+  }
+
+  @Test
+  void nonFrozenCollectionEmptyRepresentationParseDefaultsToNull() {
+    assertEquals(NonFrozenCollectionEmptyRepresentation.NULL, parse(null));
+    assertEquals(NonFrozenCollectionEmptyRepresentation.NULL, parse(""));
+    assertEquals(NonFrozenCollectionEmptyRepresentation.NULL, parse("invalid"));
+  }
+
+  @Test
+  void nonFrozenCollectionEmptyRepresentationParseIsCaseInsensitive() {
+    assertEquals(NonFrozenCollectionEmptyRepresentation.NULL, parse("NULL"));
+    assertEquals(NonFrozenCollectionEmptyRepresentation.EMPTY, parse(" Empty "));
+  }
+
+  private NonFrozenCollectionEmptyRepresentation parse(String value) {
+    return NonFrozenCollectionEmptyRepresentation.parse(value);
+  }
+}

--- a/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaNonFrozenCollectionEmptyRepresentationIT.java
+++ b/src/test/java/com/scylladb/cdc/debezium/connector/ScyllaNonFrozenCollectionEmptyRepresentationIT.java
@@ -1,0 +1,113 @@
+package com.scylladb.cdc.debezium.connector;
+
+import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromJson;
+import static com.scylladb.cdc.debezium.connector.JsonTestUtils.extractIdFromKeyField;
+
+import java.util.List;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Test;
+
+/** Tests configurable empty representation for ambiguous non-frozen collection values. */
+public class ScyllaNonFrozenCollectionEmptyRepresentationIT extends ScyllaTypesIT<String, String> {
+
+  @Override
+  protected String createTableCql(String tableName) {
+    return "(id int PRIMARY KEY, list_col list<int>, set_col set<text>, map_col map<int, text>)";
+  }
+
+  @Override
+  KafkaConsumer<String, String> buildConsumer(String connectorName, String tableName) {
+    KafkaConsumer<String, String> consumer = KafkaUtils.createStringConsumer();
+    Properties props = KafkaConnectUtils.createCommonConnectorProperties();
+    props.put("topic.prefix", connectorName);
+    props.put("scylla.table.names", tableName);
+    props.put("name", connectorName);
+    props.put("cdc.output.format", "advanced");
+    props.put("cdc.include.before", "full");
+    props.put("cdc.include.after", "full");
+    props.put("cdc.include.primary-key.placement", KafkaConnectUtils.DEFAULT_PK_PLACEMENT);
+    props.put(ScyllaConnectorConfig.CDC_NON_FROZEN_COLLECTION_EMPTY_REPRESENTATION_KEY, "empty");
+    KafkaConnectUtils.registerConnector(props, connectorName);
+    consumer.subscribe(List.of(connectorName + "." + tableName));
+    return consumer;
+  }
+
+  @Override
+  protected int extractPkFromValue(String value) {
+    int pk = extractIdFromKeyField(value);
+    if (pk != -1) {
+      return pk;
+    }
+    return extractIdFromJson(value);
+  }
+
+  @Override
+  protected int extractPkFromKey(String key) {
+    return extractIdFromJson(key);
+  }
+
+  @Test
+  void insertEmptyNonFrozenCollectionsCanEmitEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO %s (id, list_col, set_col, map_col) VALUES (%d, [], {}, {})"
+            .formatted(getSuiteKeyspaceTableName(), pk));
+
+    waitAndAssert(
+        pk, new String[] {expectedRecord("c", "null", afterEmpty(pk), expectedKeyFor(pk))});
+  }
+
+  @Test
+  void insertNullNonFrozenCollectionsCanEmitEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO %s (id, list_col, set_col, map_col) VALUES (%d, null, null, null)"
+            .formatted(getSuiteKeyspaceTableName(), pk));
+
+    waitAndAssert(
+        pk, new String[] {expectedRecord("c", "null", afterEmpty(pk), expectedKeyFor(pk))});
+  }
+
+  @Test
+  void updateFromValueToEmptyNonFrozenCollectionsCanEmitEmpty() {
+    int pk = reservePk();
+    session.execute(
+        "INSERT INTO %s (id, list_col, set_col, map_col) VALUES (%d, [10], {'x'}, {10: 'ten'})"
+            .formatted(getSuiteKeyspaceTableName(), pk));
+    session.execute(
+        "UPDATE %s SET list_col = [], set_col = {}, map_col = {} WHERE id = %d"
+            .formatted(getSuiteKeyspaceTableName(), pk));
+
+    waitAndAssert(
+        pk,
+        new String[] {
+          expectedRecord("c", "null", afterWithValues(pk), expectedKeyFor(pk)),
+          expectedRecord("u", afterWithValues(pk), afterEmpty(pk), expectedKeyFor(pk))
+        });
+  }
+
+  private String expectedKeyFor(int pk) {
+    return "{\"id\": %d}".formatted(pk);
+  }
+
+  private String afterEmpty(int pk) {
+    return afterCollections(pk, "[]", "[]", "[]");
+  }
+
+  private String afterWithValues(int pk) {
+    return afterCollections(pk, "[10]", "[\"x\"]", "[{\"key\": 10, \"value\": \"ten\"}]");
+  }
+
+  private String afterCollections(int pk, String listValue, String setValue, String mapValue) {
+    return """
+        {
+          "id": %d,
+          "list_col": %s,
+          "set_col": %s,
+          "map_col": %s
+        }
+        """
+        .formatted(pk, listValue, setValue, mapValue);
+  }
+}


### PR DESCRIPTION
## Motivation
Fixes #201.

Scylla CDC cannot distinguish explicit NULL from explicit empty non-frozen collections when no element-level changes are present. Preserve the current default null behavior, but allow users to opt into empty collection output.

## Changes
- Add `cdc.non-frozen-collections.empty-representation` with values `null` and `empty`, defaulting to `null`.
- Emit `[]` for ambiguous missing top-level non-frozen list/set/map values when configured with `empty`.
- Document the behavior and expose the default in the quickstart connector config.
- Add unit coverage for the config and an integration test for INSERT/UPDATE non-frozen collection behavior.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -DskipITs test`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn fmt:check`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -Dit.test=ScyllaNonFrozenCollectionEmptyRepresentationIT verify`
