### PR TITLE
deps(cve): bump scylla-driver to 3.11.5.17 and scylla-cdc-java to 1.3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,8 +222,8 @@
         <debezium.version>2.7.4.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>8.1.1-ccs</kafka.version>
-        <scylla.driver.version>3.11.5.11</scylla.driver.version>
-        <scylla.cdc.java.version>1.3.11</scylla.cdc.java.version>
+        <scylla.driver.version>3.11.5.17</scylla.driver.version>
+        <scylla.cdc.java.version>1.3.12</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.4</log4j.version>
@@ -310,19 +310,6 @@
                 <groupId>com.google.flogger</groupId>
                 <artifactId>flogger-log4j-backend</artifactId>
                 <version>${flogger.version}</version>
-            </dependency>
-            <!-- CVE-2026-44249, CVE-2026-45416: force netty to 4.2.15.Final;
-                 remove once scylladb/scylla-cdc-java bumps netty and a new
-                 scylla-cdc-driver3 release is consumed here (Stage 3). -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>4.2.15.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.2.15.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
🤖: Stage 3 of the netty/jackson CVE remediation for the ScyllaDB CDC Source Connector.

## What
- Bump `scylla.driver.version` `3.11.5.11` → `3.11.5.17`
- Bump `scylla.cdc.java.version` `1.3.11` → `1.3.12`
- Remove the Stage 1 `netty-common` / `netty-handler` `dependencyManagement` overrides (they are no longer needed — the fixed netty now arrives transitively).

## Why
The earlier Stage 1 release (v2.0.3) pinned netty via `dependencyManagement` as a stopgap. Now that the fix is available upstream in the driver and scylla-cdc-java, we consume it transitively instead of pinning:

- **scylla-java-driver 3.11.5.17** — netty `4.1.135.Final`, jackson-databind `2.18.9`
- **scylla-cdc-java 1.3.12** — shaded `scylla-cdc-driver3` embeds netty `4.1.135.Final` and jackson `2.18.9`

Connector-owned jackson is already at `2.22.1` on master (above all CVE thresholds).

## CVEs resolved (shaded connector jar)
- netty: CVE-2026-44249, CVE-2026-45416, CVE-2026-50010
- jackson-databind: CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518

## Verification
`mvn dependency:tree` after the change:
- `io.netty:*` → all `4.1.135.Final`
- `jackson-core` / `jackson-databind` → `2.22.1`, `jackson-annotations` → `2.22`

No competing transitive versions remain. Project compiles on JDK 17 (`--release 11`).