### PR TITLE
deps(cve): bump lz4-java to 1.11.1 and pin netty to 4.1.136.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- CVE-2026-59901 (netty-codec bzip2 infinite loop): force the netty family to
+                 4.1.136.Final, overriding the 4.1.135.Final that arrives via
+                 scylla-driver-core -> netty-handler. The netty copy shaded into
+                 scylla-cdc-driver3 is NOT covered by this - remove this import once a
+                 scylla-cdc-java release ships netty >= 4.1.136.Final and a matching
+                 scylla-driver-core is consumed here. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.136.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-avro-serializer</artifactId>
@@ -379,10 +392,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- CVE-2026-59949: JNI XXHash range validation; fixed in 1.11.1. -->
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.10.2</version>
+            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>


### PR DESCRIPTION
Remediates the CVEs reported by the Confluent Hub vulnerability scan of the published **v2.0.4** artifact.

Refs #293

## What

- Bump the direct `at.yawk.lz4:lz4-java` dependency `1.10.2` → `1.11.1`
- Import `io.netty:netty-bom:4.1.136.Final` in `dependencyManagement`

No source changes — both are dependency-level bumps.

## Why

| CVE | Package | 2.0.4 | This PR | Severity |
|---|---|---|---|---|
| CVE-2026-59949 | `at.yawk.lz4:lz4-java` | 1.10.2 | **1.11.1** | MEDIUM (6.5) |
| CVE-2026-59901 | `io.netty:netty-codec` | 4.1.135.Final | **4.1.136.Final** | HIGH |

**CVE-2026-59949** — the JNI-backed XXHash implementations did not validate their byte array arguments, so a null array or an out-of-range `off`/`len` could crash the JVM in `GetPrimitiveArrayCritical`. Fixed upstream in 1.11.1 with no user-code changes required. `1.11.1` keeps the identical `net/jpountz/**` package layout, so it is a drop-in replacement.

**CVE-2026-59901** — `Bzip2Decoder` can be driven into a permanent infinite loop in the RLE state machine of `Bzip2BlockDecompressor.read()`, capturing the event-loop thread. The unshaded netty family reaches us at 4.1.135.Final via `com.scylladb:scylla-driver-core:3.11.5.17` → `io.netty:netty-handler`.

A **BOM import** was chosen over pinning `netty-codec` alone so that all seven resolved modules (`netty-common`, `netty-buffer`, `netty-resolver`, `netty-transport`, `netty-transport-native-unix-common`, `netty-handler`, `netty-codec`) move together — a 4.1.136 codec next to a 4.1.135 handler would be a needless mix. The explicit netty `dependencyManagement` entries from the earlier Stage 1 round were removed in 53bc6df, so there is nothing left to conflict with this import.

## Known remaining after this PR

The scan lists CVE-2026-59901 **twice**. The second occurrence is a copy of netty relocated into `scylla-cdc-driver3-1.3.12.jar`, which `dependencyManagement` cannot reach — the vulnerable bytecode is physically embedded in the upstream artifact:

```
$ unzip -p scylla-cdc-driver3-1.3.12.jar META-INF/io.netty.versions.properties
netty-handler.version=4.1.135.Final

$ unzip -l scylla-cdc-driver3-1.3.12.jar | grep Bzip2BlockDecompressor
shaded/com/scylladb/cdc/driver3/handler/codec/compression/Bzip2BlockDecompressor.class
```

`scylla-cdc-driver3` is at `1.3.12` (latest) and `scylla-driver-core` at `3.11.5.17` (latest), so there is nothing newer to consume yet. Clearing it needs a `scylla-cdc-java` release built against netty ≥ 4.1.136.Final — tracked as the Stage 2 follow-up in #293, which is why this PR uses `Refs` rather than `Closes`.

Practical exposure for that remaining copy is effectively nil: `Bzip2Decoder` only runs when a bzip2 handler is installed on a netty pipeline, and the Scylla CQL native protocol offers LZ4/Snappy frame compression only — the driver never installs it. Scanners flag it by class presence.

## Verification

**Resolution** — all seven netty modules move as a set, and no 4.1.135 artifact survives:

```
$ mvn dependency:tree
+- at.yawk.lz4:lz4-java:jar:1.11.1:compile
+- com.scylladb:scylla-driver-core:jar:3.11.5.17:compile
|  +- io.netty:netty-handler:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-common:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-resolver:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-buffer:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport-native-unix-common:jar:4.1.136.Final:compile
|  |  \- io.netty:netty-codec:jar:4.1.136.Final:compile

$ grep -c '4.1.135.Final' <tree>
0
```

**Packaged artifact** — the Confluent Hub component archive is what the scan reads, and its `lib/` filenames now match the fixed versions (these filenames are exactly the `PkgPath` values from the report):

```
$ unzip -l target/components/packages/scylladb-scylla-cdc-source-connector-2.0.5-SNAPSHOT.zip
  .../lib/lz4-java-1.11.1.jar                     (was lz4-java-1.10.2.jar)
  .../lib/netty-codec-4.1.136.Final.jar           (was netty-codec-4.1.135.Final.jar)
  .../lib/netty-{common,buffer,resolver,transport,transport-native-unix-common,handler}-4.1.136.Final.jar
  .../lib/scylla-cdc-driver3-1.3.12.jar           (unchanged — shaded netty, see above)
```

**Build** — `mvn -B -DskipITs package` on JDK 17: `BUILD SUCCESS`, `Tests run: 141, Failures: 0, Errors: 0, Skipped: 0`. `fmt-maven-plugin` check and the enforcer Java-version rule both pass.

The full 8-combination integration matrix runs on this PR via `pr-verify.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
