### PR TITLE
deps(cve): consume fixed upstream (driver 3.11.5.18, cdc-java 1.3.13) and drop the netty-bom stopgap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,8 +222,8 @@
         <debezium.version>2.7.4.Final</debezium.version>
         <!-- Docs claim java 8 supported, but support is deprecated -->
         <kafka.version>8.1.1-ccs</kafka.version>
-        <scylla.driver.version>3.11.5.17</scylla.driver.version>
-        <scylla.cdc.java.version>1.3.12</scylla.cdc.java.version>
+        <scylla.driver.version>3.11.5.18</scylla.driver.version>
+        <scylla.cdc.java.version>1.3.13</scylla.cdc.java.version>
         <flogger.version>0.5.1</flogger.version>
         <!-- added for transitive dependencies -->
         <log4j.version>2.25.4</log4j.version>
@@ -320,19 +320,6 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>6.0.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- CVE-2026-59901 (netty-codec bzip2 infinite loop): force the netty family to
-                 4.1.136.Final, overriding the 4.1.135.Final that arrives via
-                 scylla-driver-core -> netty-handler. The netty copy shaded into
-                 scylla-cdc-driver3 is NOT covered by this - remove this import once a
-                 scylla-cdc-java release ships netty >= 4.1.136.Final and a matching
-                 scylla-driver-core is consumed here. -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.136.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
> [!NOTE]
> **Unblocked — both upstream releases are out.**
> - ✅ `scylla-driver-core:3.11.5.18` — scylladb/java-driver#990 merged, [published 2026-08-18](https://github.com/scylladb/java-driver/releases/tag/3.11.5.18)
> - ✅ `scylla-cdc-java:1.3.13` — scylladb/scylla-cdc-java#188 merged 2026-08-19, released the same day (tag `scylla-cdc-1.3.13`, on Central 14:45 UTC)
>
> Everything below is now verified against the **published** artifacts, with no `-D` overrides.
>
> Note: v2.0.5 already shipped from `master` carrying the stopgap pin and cdc-java 1.3.12, so the shaded
> finding is still present in the published 2.0.5 artifact. This change lands in 2.0.6-SNAPSHOT.

Stage 2, the end of the CVE remediation started in #293/#294: consume the fixed upstream artifacts and delete the stopgap.

## What

- `scylla.driver.version` `3.11.5.17` → **`3.11.5.18`**
- `scylla.cdc.java.version` `1.3.12` → **`1.3.13`**
- **Remove** the `io.netty:netty-bom:4.1.136.Final` `dependencyManagement` import added in `c0e03e3`

Net effect on `pom.xml`: +2 / −15.

## Why

The `netty-bom` pin from Stage 1 was always a stopgap. It fixed the *unshaded* netty that the connector resolves through `scylla-driver-core`, but it could not touch the copy **relocated** into `scylla-cdc-driver3.jar` — `dependencyManagement` cannot reach `shaded.com.scylladb.cdc.driver3.*` bytecode. That is why #293 stayed open after #294.

Stage 2 fixes it at the root instead. scylladb/java-driver#990 bumped `netty.version` → 4.1.136.Final and `lz4.version` → 1.11.1 on `scylla-3.x`; scylladb/scylla-cdc-java#188 rebuilt the shaded jar against that driver. Both now arrive here transitively, so the pin is dead weight and comes out.

## All three CVE_Report.csv rows now clear

Verified against the real releases — the local `~/.m2` copies of `scylla-cdc-*:1.3.13-SNAPSHOT` and
`scylla-driver-core:3.11.5.18-SNAPSHOT` were deleted first, so resolution had to come from Central:

```
$ mvn -B -DskipITs package          # no -D overrides
[INFO] Tests run: 141, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

$ cat ~/.m2/repository/com/scylladb/scylla-cdc-driver3/1.3.13/_remote.repositories
scylla-cdc-driver3-1.3.13.pom>central=
scylla-cdc-driver3-1.3.13.jar>central=
```

Inspecting the Confluent Hub component archive — the artifact the scan actually reads, since the report's `PkgPath` values are `lib/` jar filenames:

| Report row | Before (v2.0.4) | Now |
|---|---|---|
| CVE-2026-59949 | `lz4-java-1.10.2.jar` | ✅ `lib/lz4-java-1.11.1.jar` |
| CVE-2026-59901 (unshaded) | `netty-codec-4.1.135.Final.jar` | ✅ `lib/netty-codec-4.1.136.Final.jar` |
| CVE-2026-59901 (**shaded**) | `scylla-cdc-driver3-1.3.12.jar` @ 4.1.135.Final | ✅ `lib/scylla-cdc-driver3-1.3.13.jar` @ **4.1.136.Final** |

```
$ ZIP=target/components/packages/scylladb-scylla-cdc-source-connector-2.0.6-SNAPSHOT.zip

$ unzip -l $ZIP | grep -c 4.1.135
0

$ unzip -l $ZIP | grep -E 'netty|lz4|scylla-cdc-driver3'
  .../lib/lz4-java-1.11.1.jar
  .../lib/netty-buffer-4.1.136.Final.jar
  .../lib/netty-codec-4.1.136.Final.jar
  .../lib/netty-common-4.1.136.Final.jar
  .../lib/netty-handler-4.1.136.Final.jar
  .../lib/netty-resolver-4.1.136.Final.jar
  .../lib/netty-transport-4.1.136.Final.jar
  .../lib/netty-transport-native-unix-common-4.1.136.Final.jar
  .../lib/scylla-cdc-driver3-1.3.13.jar
```

Zero `4.1.135` references anywhere in the archive. And for the shaded row specifically — the one thing no
downstream pin could ever fix — the *published* 1.3.13 jar carries the patched relocated bytecode:

```
$ unzip -p $ZIP '*/lib/scylla-cdc-driver3-1.3.13.jar' > driver3.jar

$ unzip -p driver3.jar META-INF/io.netty.versions.properties
netty-handler.version=4.1.136.Final

$ unzip -l driver3.jar | grep -c 4.1.135
0

$ unzip -p driver3.jar \
    shaded/com/scylladb/cdc/driver3/handler/codec/compression/Bzip2BlockDecompressor.class | sha256sum
28c564a398e3668ea6b951625f836a29018fd11d244b2e9a2acd59d4c066d5be     # 1.3.13  (patched)
8bf9b7531a1c2f153cfe96eeaafe82a031a8b76bf840f72be994418193d7d2b8     # 1.3.12  (vulnerable, for contrast)
```

`Bzip2BlockDecompressor` is the class CVE-2026-59901 lives in (the RLE `read()` infinite loop). Different
hash under the relocated package means the shipped, shaded copy really is the fixed state machine — not just
a renamed jar.

The netty family also still resolves as a coherent set (all 7 modules at 4.1.136.Final) **without** the BOM pin, confirming the transitive path is doing the work:

```
$ mvn dependency:tree
com.scylladb:scylla-cdc-source-connector:jar:2.0.6-SNAPSHOT
+- com.scylladb:scylla-cdc-base:jar:1.3.13:compile
+- com.scylladb:scylla-cdc-driver3:jar:1.3.13:compile
+- at.yawk.lz4:lz4-java:jar:1.11.1:compile
+- com.scylladb:scylla-driver-core:jar:3.11.5.18:compile
|  +- io.netty:netty-handler:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-common:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-resolver:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-buffer:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport-native-unix-common:jar:4.1.136.Final:compile
|  |  \- io.netty:netty-codec:jar:4.1.136.Final:compile
```

`lz4-java` stays declared at 1.11.1 here: the connector's own direct dependency still wins over the driver's `lz4.version`, and Kafka's LZ4 codec needs it on the classpath regardless.

## Verification checklist before un-drafting

- [x] scylladb/java-driver#990 merged and `scylla-3.x` released as 3.11.5.18 — on Central 2026-08-18; `scylla-driver-parent-3.11.5.18.pom` declares `netty.version=4.1.136.Final` and `lz4.version=1.11.1`
- [x] scylladb/scylla-cdc-java#188 merged and released as 1.3.13 — merged 2026-08-19, on Central the same day; the published shaded jar reads `netty-handler.version=4.1.136.Final` and its relocated `Bzip2BlockDecompressor.class` hashes `28c564a3…` vs 1.3.12's `8bf9b753…`
- [x] #294 merged, this branch rebased onto `master` — single commit on `e31432f`, +2 / −15
- [x] Re-run the build with the real release versions (drop the `-D` overrides) and confirm the table above — 141 tests green, both artifacts resolved from `central`
- [x] Re-scan the published artifact to confirm the report comes back empty — zero `4.1.135` references in the component archive, all three report rows accounted for above

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
