### PR TITLE
fix(release): restore tag-based GitHub release titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ github-release:
 		gh release create "$(RELEASE_TAG)" \
 			"$(FAT_JAR)" \
 			"$(CONNECT_ZIP)" \
-			--title "Release $(RELEASE_VERSION)" \
+			--title "$(RELEASE_TAG)" \
 			--generate-notes; \
 	fi


### PR DESCRIPTION
Since v2.0.1, automated releases have been titled `Release X.Y.Z` instead of `vX.Y.Z`, unlike all prior releases. This reverts the `github-release` Makefile target to title releases after the tag again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)