### PR TITLE
ci: block releases with open release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,28 @@ jobs:
       MVNCMD: mvn -B -X -ntp
 
     steps:
+      - name: Check for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker=$(gh issue list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --label release-blocker \
+            --limit 1 \
+            --json title,url \
+            --jq '.[0] // empty')
+          if [[ -n "${blocker}" ]]; then
+            blocker_title=$(jq -r '.title' <<< "${blocker}")
+            blocker_url=$(jq -r '.url' <<< "${blocker}")
+            echo "::error title=Release blocked::${blocker_title} (${blocker_url})"
+            echo "Open release blocker: ${blocker_title} (${blocker_url})"
+            exit 1
+          fi
+          echo "No open release blockers found."
+
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,28 @@ jobs:
           export MAVEN_OPTS
           $MVNCMD release:prepare -DpushChanges=false ${NEXT_RELEASE} -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Recheck for open release blockers
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          blocker=$(gh issue list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --label release-blocker \
+            --limit 1 \
+            --json title,url \
+            --jq '.[0] // empty')
+          if [[ -n "${blocker}" ]]; then
+            blocker_title=$(jq -r '.title' <<< "${blocker}")
+            blocker_url=$(jq -r '.url' <<< "${blocker}")
+            echo "::error title=Release blocked::${blocker_title} (${blocker_url})"
+            echo "Open release blocker: ${blocker_title} (${blocker_url})"
+            exit 1
+          fi
+          echo "No open release blockers found."
+
       - name: Perform release
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary

- block production releases when an open issue has the release-blocker label
- report blocking issue title and URL
- keep dry-run releases available
- grant or reuse minimum workflow-token issue access needed by the check

## Validation

- actionlint 1.7.12
- guard succeeds when no blocker exists
- guard fails when an open blocker exists
- API failures fail closed